### PR TITLE
ci: enforce the spec-ci-plugin asset contract instead of describing it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,3 +346,108 @@ jobs:
 
             ## Checksums
             See `SHA256SUMS.txt` for verification.
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # JOB 4: verify-published-assets  (issue #18)
+  # ──────────────────────────────────────────────────────────────────────────
+  # The ASSET CONTRACT block at the top of this file DESCRIBES the coupling to
+  # spec-ci-plugin. Job 3 validates the artifacts it is about to upload. Neither
+  # checks what a consumer actually sees: the published download URL.
+  #
+  # That gap is real. A release can be green while the upload glob silently stops
+  # matching, or an asset is renamed, or the tag segment of the URL differs from
+  # what the Action pins — and the breakage surfaces in ANOTHER repository's CI,
+  # which is where it is hardest to diagnose.
+  #
+  # This job walks the consumer's exact path, unauthenticated, over the public
+  # download URL, at the tag just pushed:
+  #     curl -> HTTP 200 -> raw ELF of the right architecture -> --version
+  # plus SHA256SUMS.txt, which the Action now verifies before executing
+  # (spec-ci-plugin #9 / injection-scanner #43).
+  #
+  # It runs AFTER the release is published, so a failure here does not prevent a
+  # broken release — it makes one impossible to miss. Fix and re-tag.
+  verify-published-assets:
+    name: Verify published asset contract (spec-ci-plugin)
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read     # the assets are fetched anonymously, exactly as the Action does
+    steps:
+      - name: Fetch and verify the musl pair + checksum manifest at this tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          BASE="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+          WORK="$(mktemp -d)"; cd "$WORK"
+
+          # Asset publication is not instantaneous. Retry rather than racing it.
+          fetch() {
+            local name="$1"
+            for attempt in 1 2 3 4 5; do
+              if curl -fsSL --retry 3 --max-time 60 -o "$name" "${BASE}/${name}"; then
+                echo "  fetched ${name} ($(wc -c < "$name") bytes)"
+                return 0
+              fi
+              echo "  attempt ${attempt} failed for ${name}; retrying in 5s"
+              sleep 5
+            done
+            echo "::error::${BASE}/${name} did not return 200. The spec-ci-plugin Action" \
+                 "downloads this exact URL and will break. See issue #18."
+            return 1
+          }
+
+          # e_machine, offset 18, little-endian: x86_64 = 3e00, aarch64 = b700.
+          expected_machine() {
+            case "$1" in
+              x86_64)  echo "3e00" ;;
+              aarch64) echo "b700" ;;
+              *) echo "::error::unknown arch $1"; exit 1 ;;
+            esac
+          }
+
+          for arch in x86_64 aarch64; do
+            ASSET="injection-scanner-${arch}-unknown-linux-musl"
+            echo "── ${ASSET}"
+            fetch "$ASSET"
+
+            # RAW executable, not an archive. Checked by magic bytes rather than
+            # by extension, because the contract is precisely that there is no
+            # extension to check.
+            MAGIC="$(head -c 4 "$ASSET" | od -An -tx1 | tr -d ' \n')"
+            if [ "$MAGIC" != "7f454c46" ]; then
+              echo "::error::${ASSET} is not an ELF binary (magic ${MAGIC}). The Action chmods and" \
+                   "executes this file directly — it must be a raw binary, never a tarball."
+              exit 1
+            fi
+
+            MACHINE="$(od -An -tx1 -j18 -N2 "$ASSET" | tr -d ' \n')"
+            WANT="$(expected_machine "$arch")"
+            if [ "$MACHINE" != "$WANT" ]; then
+              echo "::error::${ASSET} reports ELF machine ${MACHINE}, expected ${WANT} for ${arch}."
+              exit 1
+            fi
+            echo "  ELF ok, machine ${MACHINE}"
+          done
+
+          # The manifest the Action verifies against before it executes anything.
+          echo "── SHA256SUMS.txt"
+          fetch "SHA256SUMS.txt"
+          for arch in x86_64 aarch64; do
+            ASSET="injection-scanner-${arch}-unknown-linux-musl"
+            if ! grep -q " ${ASSET}\$" SHA256SUMS.txt; then
+              echo "::error::SHA256SUMS.txt does not list ${ASSET}. The spec-ci-plugin Action" \
+                   "verifies against this manifest and will refuse to run the binary."
+              exit 1
+            fi
+          done
+          sha256sum -c --ignore-missing SHA256SUMS.txt
+          echo "  checksums verified"
+
+          # Finally, run it — the runner is x86_64, so only that one is native.
+          chmod +x injection-scanner-x86_64-unknown-linux-musl
+          ./injection-scanner-x86_64-unknown-linux-musl --version
+          printf '# doc\n\nordinary prose\n' > sample.md
+          ./injection-scanner-x86_64-unknown-linux-musl check sample.md
+          echo "Published asset contract verified at ${TAG}."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,13 +385,18 @@ jobs:
           # Asset publication is not instantaneous. Retry rather than racing it.
           fetch() {
             local name="$1"
+            local delay=5
             for attempt in 1 2 3 4 5; do
               if curl -fsSL --retry 3 --max-time 60 -o "$name" "${BASE}/${name}"; then
                 echo "  fetched ${name} ($(wc -c < "$name") bytes)"
                 return 0
               fi
-              echo "  attempt ${attempt} failed for ${name}; retrying in 5s"
-              sleep 5
+              # Back off rather than spending the whole budget in 20s. Asset
+              # publication is usually fast, but under load the fixed 5s x 5
+              # window was too short to be worth having.
+              echo "  attempt ${attempt} failed for ${name}; retrying in ${delay}s"
+              sleep "$delay"
+              delay=$(( delay * 2 ))
             done
             echo "::error::${BASE}/${name} did not return 200. The spec-ci-plugin Action" \
                  "downloads this exact URL and will break. See issue #18."
@@ -442,6 +447,11 @@ jobs:
               exit 1
             fi
           done
+          # --ignore-missing because the manifest lists all six target-triple
+          # binaries while this job downloads only the two musl ones. The grep
+          # above is what makes that safe: it already failed the job if either
+          # consumer asset were absent from the manifest, so this cannot pass
+          # vacuously by skipping the files it is meant to check.
           sha256sum -c --ignore-missing SHA256SUMS.txt
           echo "  checksums verified"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,42 @@ defend it, and they do different jobs:
 
 If you touch `Scanner`, run both.
 
+## The release asset contract
+
+`spec-ci-plugin` (tool 04) downloads and executes two of this repository's release
+assets directly, at a pinned tag, with **no file extension**:
+
+```
+injection-scanner-x86_64-unknown-linux-musl
+injection-scanner-aarch64-unknown-linux-musl
+```
+
+It `chmod +x`es what it downloads and runs it, after verifying the bytes against
+`SHA256SUMS.txt` from the same release. So these names, and the fact that they are
+raw executables rather than archives, are a **public API of this repository**.
+Renaming one, switching to tarballs, changing a target triple, or dropping a musl
+leg is a breaking change for another repository's CI, whatever this repo's version
+number says — and it surfaces there, not here, which is the hardest place to
+diagnose it.
+
+Two things enforce it, and they see different failures:
+
+- `tests/release_contract_test.rs` runs in the ordinary `cargo test` gate. It parses
+  `.github/workflows/release.yml` as YAML and checks the workflow still *produces*
+  the names the consumer *requests*: both musl targets are in the build matrix and
+  not `experimental`, the upload globs still select them, the attestation
+  `subject-path` still covers them, and the packaging step still emits a raw
+  target-triple-named binary. Break the contract in a pull request and it fails
+  there.
+- `verify-published-assets` in `release.yml` runs after the release is published. It
+  walks the consumer's exact path — anonymous `curl` of the public download URL at
+  the new tag — and asserts HTTP 200, ELF magic, the right architecture in the ELF
+  header, presence in `SHA256SUMS.txt`, a passing checksum, and a working
+  `--version`. A workflow can be perfectly specified and still fail to upload; this
+  is what catches that.
+
+Neither can see what the other sees. If you touch `release.yml`, expect both.
+
 ## Adding a New Pattern
 
 1. Choose the appropriate category YAML file in `patterns/core/`

--- a/tests/release_contract_test.rs
+++ b/tests/release_contract_test.rs
@@ -1,0 +1,309 @@
+//! Enforces the cross-repo asset contract with `spec-ci-plugin` (issue #18).
+//!
+//! `04-spec-ci-plugin/src/injection-scanner.ts` downloads, `chmod +x`es and
+//! executes, at a pinned tag and with no file extension:
+//!
+//! ```text
+//! injection-scanner-<arch>-unknown-linux-musl        arch = x86_64 | aarch64
+//! ```
+//!
+//! That coupling was documented in a comment at the top of `release.yml` and
+//! enforced nowhere. A release that switched to tarballs, renamed an asset,
+//! changed a target triple, or simply failed to cut the musl pair would break
+//! another repository's CI — the hardest place to diagnose it.
+//!
+//! These tests read `release.yml` as data, not as text, and check that the
+//! workflow still *produces* the exact names the consumer *requests*. They run
+//! in the ordinary `cargo test` gate, so the failure lands on the pull request
+//! that changes the workflow rather than on whoever next upgrades tool 04.
+//!
+//! The complementary half runs at release time: `verify-published-assets` in
+//! `release.yml` fetches the published URLs and checks they are raw ELF binaries
+//! of the right architecture. This file cannot see that — a workflow can be
+//! perfectly specified and still fail to upload — and that job cannot see this,
+//! since it only runs on a tag. Both are needed.
+
+use serde_yaml::Value;
+
+/// The asset names `spec-ci-plugin` builds its download URL from.
+///
+/// Changing either of these is a breaking change for tool 04, whatever this
+/// repository's own version number says.
+const CONSUMER_ASSETS: [&str; 2] = [
+    "injection-scanner-x86_64-unknown-linux-musl",
+    "injection-scanner-aarch64-unknown-linux-musl",
+];
+
+const CHECKSUM_MANIFEST: &str = "SHA256SUMS.txt";
+
+fn release_workflow() -> Value {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/.github/workflows/release.yml");
+    let text = std::fs::read_to_string(path).expect("release.yml must exist");
+    serde_yaml::from_str(&text).expect("release.yml must be valid YAML")
+}
+
+fn job<'a>(workflow: &'a Value, name: &str) -> &'a Value {
+    workflow
+        .get("jobs")
+        .and_then(|jobs| jobs.get(name))
+        .unwrap_or_else(|| panic!("release.yml must define a `{name}` job"))
+}
+
+fn steps(job: &Value) -> &[Value] {
+    job.get("steps")
+        .and_then(Value::as_sequence)
+        .expect("job must have steps")
+        .as_slice()
+}
+
+/// Find a step whose `name` contains `needle`.
+fn step_named<'a>(steps: &'a [Value], needle: &str) -> &'a Value {
+    steps
+        .iter()
+        .find(|s| {
+            s.get("name")
+                .and_then(Value::as_str)
+                .is_some_and(|n| n.contains(needle))
+        })
+        .unwrap_or_else(|| panic!("no step whose name contains {needle:?}"))
+}
+
+/// Match a shell-style glob containing `*` against a literal name.
+///
+/// Deliberately minimal: the point is to answer "does the workflow's upload
+/// pattern still select this exact asset", and the patterns in question use
+/// nothing more exotic than `*`.
+fn glob_matches(pattern: &str, name: &str) -> bool {
+    let mut remaining = name;
+    let mut segments = pattern.split('*');
+
+    let first = segments.next().unwrap_or("");
+    match remaining.strip_prefix(first) {
+        Some(rest) => remaining = rest,
+        None => return false,
+    }
+
+    let mut last_was_wildcard = true;
+    let mut trailing = "";
+    for segment in segments {
+        trailing = segment;
+        last_was_wildcard = true;
+        if segment.is_empty() {
+            continue;
+        }
+        match remaining.find(segment) {
+            Some(at) => {
+                remaining = &remaining[at + segment.len()..];
+                last_was_wildcard = false;
+            }
+            None => return false,
+        }
+    }
+
+    // A pattern not ending in `*` must consume the whole name.
+    if !trailing.is_empty() && !last_was_wildcard {
+        return remaining.is_empty();
+    }
+    if pattern.ends_with('*') {
+        return true;
+    }
+    remaining.is_empty()
+}
+
+fn build_matrix_targets(workflow: &Value) -> Vec<(String, bool)> {
+    job(workflow, "build-binaries")
+        .get("strategy")
+        .and_then(|s| s.get("matrix"))
+        .and_then(|m| m.get("include"))
+        .and_then(Value::as_sequence)
+        .expect("build-binaries must use a matrix include list")
+        .iter()
+        .map(|entry| {
+            let target = entry
+                .get("target")
+                .and_then(Value::as_str)
+                .expect("each matrix entry needs a target")
+                .to_string();
+            let experimental = entry
+                .get("experimental")
+                .and_then(Value::as_bool)
+                .expect("each matrix entry needs an experimental flag");
+            (target, experimental)
+        })
+        .collect()
+}
+
+fn patterns_from(step: &Value, key: &str) -> Vec<String> {
+    step.get("with")
+        .and_then(|w| w.get(key))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("step must declare `{key}`"))
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn release_file_patterns(workflow: &Value) -> Vec<String> {
+    let steps = steps(job(workflow, "release"));
+    patterns_from(step_named(steps, "Create GitHub Release"), "files")
+}
+
+fn attestation_subject_patterns(workflow: &Value) -> Vec<String> {
+    let steps = steps(job(workflow, "release"));
+    patterns_from(step_named(steps, "Attest build provenance"), "subject-path")
+}
+
+fn selects(patterns: &[String], asset: &str) -> bool {
+    patterns.iter().any(|pattern| {
+        let file_part = pattern.rsplit('/').next().unwrap_or(pattern);
+        glob_matches(file_part, asset)
+    })
+}
+
+#[test]
+fn musl_targets_are_built_and_are_not_experimental() {
+    let workflow = release_workflow();
+    let targets = build_matrix_targets(&workflow);
+
+    for asset in CONSUMER_ASSETS {
+        let triple = asset
+            .strip_prefix("injection-scanner-")
+            .expect("consumer assets are prefixed with the binary name");
+        let entry = targets
+            .iter()
+            .find(|(t, _)| t == triple)
+            .unwrap_or_else(|| {
+                panic!(
+                    "release.yml no longer builds `{triple}`, but spec-ci-plugin downloads \
+                 `{asset}` and executes it. See issue #18."
+                )
+            });
+        assert!(
+            !entry.1,
+            "`{triple}` is marked experimental, so a failure would be tolerated by \
+             continue-on-error and the release would ship without an asset spec-ci-plugin \
+             requires. The musl pair is hard-required. See issue #18."
+        );
+    }
+}
+
+#[test]
+fn published_globs_still_select_the_consumer_assets() {
+    let workflow = release_workflow();
+    let patterns = release_file_patterns(&workflow);
+
+    for asset in CONSUMER_ASSETS.iter().chain([&CHECKSUM_MANIFEST]) {
+        assert!(
+            selects(&patterns, asset),
+            "no upload pattern in release.yml selects `{asset}`. Patterns are {patterns:?}. \
+             spec-ci-plugin downloads this exact name from the release. See issue #18."
+        );
+    }
+}
+
+/// The consumer assets must also be covered by the provenance attestation.
+///
+/// This is a separate glob list from the upload one, and nothing keeps the two
+/// in step. An asset dropped from `subject-path` still ships — silently without
+/// the signed provenance the release notes tell people to verify.
+#[test]
+fn attestation_covers_the_consumer_assets() {
+    let workflow = release_workflow();
+    let patterns = attestation_subject_patterns(&workflow);
+
+    for asset in CONSUMER_ASSETS {
+        assert!(
+            selects(&patterns, asset),
+            "no attestation subject-path in release.yml covers `{asset}`. Patterns are \
+             {patterns:?}. It would ship without the provenance the release notes instruct \
+             consumers to verify. See issue #18."
+        );
+    }
+}
+
+#[test]
+fn assets_are_raw_binaries_named_by_target_triple() {
+    let workflow = release_workflow();
+    let package = step_named(steps(job(&workflow, "build-binaries")), "Package");
+    let script = package
+        .get("run")
+        .and_then(Value::as_str)
+        .expect("the packaging step must be a script");
+
+    assert!(
+        script.contains(r#"OUT="injection-scanner-${{ matrix.target }}""#),
+        "the packaging step no longer names the asset `injection-scanner-<target>` verbatim. \
+         spec-ci-plugin builds that name itself and appends no extension. See issue #18."
+    );
+
+    for archiver in ["tar ", "tar\n", "zip ", "gzip "] {
+        assert!(
+            !script.contains(archiver),
+            "the packaging step appears to archive the binary (`{}`). The Action chmods and \
+             executes the downloaded file directly, so it must stay a raw executable. \
+             See issue #18.",
+            archiver.trim()
+        );
+    }
+}
+
+#[test]
+fn a_published_asset_check_runs_after_the_release() {
+    let workflow = release_workflow();
+    let verify = job(&workflow, "verify-published-assets");
+    let needs = verify.get("needs").expect("verify job must declare needs");
+
+    let depends_on_release = match needs {
+        Value::String(s) => s == "release",
+        Value::Sequence(items) => items.iter().any(|i| i.as_str() == Some("release")),
+        other => panic!("unexpected `needs` shape: {other:?}"),
+    };
+    assert!(
+        depends_on_release,
+        "verify-published-assets must run after `release`, or it checks URLs that do not \
+         exist yet. See issue #18."
+    );
+
+    let script = steps(verify)
+        .iter()
+        .filter_map(|s| s.get("run").and_then(Value::as_str))
+        .collect::<String>();
+    for asset in CONSUMER_ASSETS {
+        let triple = asset.strip_prefix("injection-scanner-").unwrap();
+        let arch = triple.split('-').next().unwrap();
+        assert!(
+            script.contains(arch),
+            "the published-asset check does not mention `{arch}`, so `{asset}` is not being \
+             verified. See issue #18."
+        );
+    }
+    assert!(
+        script.contains(CHECKSUM_MANIFEST),
+        "the published-asset check must also verify {CHECKSUM_MANIFEST}: spec-ci-plugin now \
+         refuses to execute a binary it cannot check against that manifest."
+    );
+}
+
+#[test]
+fn glob_matcher_behaves() {
+    assert!(glob_matches(
+        "injection-scanner-*-unknown-linux-musl",
+        "injection-scanner-x86_64-unknown-linux-musl"
+    ));
+    assert!(glob_matches(
+        "injection-scanner-*-unknown-linux-musl",
+        "injection-scanner-aarch64-unknown-linux-musl"
+    ));
+    assert!(!glob_matches(
+        "injection-scanner-*-unknown-linux-gnu",
+        "injection-scanner-x86_64-unknown-linux-musl"
+    ));
+    assert!(!glob_matches(
+        "injection-scanner-*-unknown-linux-musl.tar.gz",
+        "injection-scanner-x86_64-unknown-linux-musl"
+    ));
+    assert!(glob_matches("SHA256SUMS.txt", "SHA256SUMS.txt"));
+    assert!(!glob_matches("SHA256SUMS.txt", "SHA256SUMS.txt.asc"));
+}

--- a/tests/release_contract_test.rs
+++ b/tests/release_contract_test.rs
@@ -266,6 +266,20 @@ fn a_published_asset_check_runs_after_the_release() {
          exist yet. See issue #18."
     );
 
+    // A `continue-on-error: true` here would leave the job green whatever it
+    // found, which is a decorative gate rather than a gate. Nothing else in the
+    // workflow would notice.
+    let tolerated = verify
+        .get("continue-on-error")
+        .map(|v| v.as_bool() != Some(false))
+        .unwrap_or(false);
+    assert!(
+        !tolerated,
+        "verify-published-assets sets `continue-on-error`, so a failed contract check would \
+         not fail the workflow. The job exists to make a broken release impossible to miss; \
+         tolerating its failure makes it decorative. See issue #18."
+    );
+
     let script = steps(verify)
         .iter()
         .filter_map(|s| s.get("run").and_then(Value::as_str))

--- a/tests/release_contract_test.rs
+++ b/tests/release_contract_test.rs
@@ -74,40 +74,41 @@ fn step_named<'a>(steps: &'a [Value], needle: &str) -> &'a Value {
 /// pattern still select this exact asset", and the patterns in question use
 /// nothing more exotic than `*`.
 fn glob_matches(pattern: &str, name: &str) -> bool {
-    let mut remaining = name;
-    let mut segments = pattern.split('*');
+    // `split` always yields at least one element, so `parts` is never empty and
+    // `first`/`last` are always valid.
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let (Some(first), Some(last)) = (parts.first(), parts.last()) else {
+        return false;
+    };
 
-    let first = segments.next().unwrap_or("");
-    match remaining.strip_prefix(first) {
-        Some(rest) => remaining = rest,
-        None => return false,
+    // No wildcard at all: the pattern is a literal filename.
+    if parts.len() == 1 {
+        return pattern == name;
     }
 
-    let mut last_was_wildcard = true;
-    let mut trailing = "";
-    for segment in segments {
-        trailing = segment;
-        last_was_wildcard = true;
-        if segment.is_empty() {
-            continue;
-        }
-        match remaining.find(segment) {
-            Some(at) => {
-                remaining = &remaining[at + segment.len()..];
-                last_was_wildcard = false;
-            }
+    // Anchor both ends before scanning the middle. Consuming the segments
+    // left-to-right with `find` — as an earlier version did — lets a middle
+    // search swallow the text the trailing segment needs, so `a*b` did not
+    // match `abxb` and `*-unknown-linux-musl` did not match a name containing
+    // that suffix twice. Those are false negatives, so the failure showed up as
+    // "this asset is not in the upload list" for an asset that was.
+    let Some(remaining) = name.strip_prefix(first) else {
+        return false;
+    };
+    let Some(mut remaining) = remaining.strip_suffix(last) else {
+        return false;
+    };
+
+    // Interior segments must appear in order in what is left between the
+    // anchors. Greedy is safe here: the tail is already reserved.
+    for segment in &parts[1..parts.len() - 1] {
+        match remaining.find(*segment) {
+            Some(at) => remaining = &remaining[at + segment.len()..],
             None => return false,
         }
     }
 
-    // A pattern not ending in `*` must consume the whole name.
-    if !trailing.is_empty() && !last_was_wildcard {
-        return remaining.is_empty();
-    }
-    if pattern.ends_with('*') {
-        return true;
-    }
-    remaining.is_empty()
+    true
 }
 
 fn build_matrix_targets(workflow: &Value) -> Vec<(String, bool)> {
@@ -301,6 +302,54 @@ fn a_published_asset_check_runs_after_the_release() {
 }
 
 #[test]
+fn the_published_asset_check_is_read_only() {
+    // This job downloads an unauthenticated artifact and executes it. That is
+    // the whole point — it walks the consumer's exact path — but it means the
+    // job runs code that is not gated on the repository's review process. It
+    // must therefore hold nothing worth stealing: no write scope, no token
+    // beyond the anonymous fetch, no secrets in its environment.
+    //
+    // The CI guidance in CLAUDE.md is specific about this split, and a
+    // `permissions:` block is easy to widen by copying a neighbouring job.
+    let workflow = release_workflow();
+    let verify = job(&workflow, "verify-published-assets");
+
+    let permissions = verify
+        .get("permissions")
+        .and_then(Value::as_mapping)
+        .expect("verify-published-assets must declare an explicit `permissions` block");
+
+    for (scope, level) in permissions {
+        let scope = scope.as_str().unwrap_or("<non-string>");
+        let level = level.as_str().unwrap_or("<non-string>");
+        assert_eq!(
+            level, "read",
+            "verify-published-assets grants `{scope}: {level}`. The job fetches assets \
+             anonymously and then executes one; it must not hold write scope on anything."
+        );
+    }
+
+    let script = steps(verify)
+        .iter()
+        .filter_map(|s| s.get("run").and_then(Value::as_str))
+        .collect::<String>();
+    let env_blocks = steps(verify)
+        .iter()
+        .filter_map(|s| s.get("env"))
+        .chain(verify.get("env"))
+        .map(|v| serde_yaml::to_string(v).unwrap_or_default())
+        .collect::<String>();
+
+    for surface in [&script, &env_blocks] {
+        assert!(
+            !surface.contains("secrets."),
+            "verify-published-assets references `secrets.`. It executes a downloaded \
+             binary — nothing secret may be reachable from it."
+        );
+    }
+}
+
+#[test]
 fn glob_matcher_behaves() {
     assert!(glob_matches(
         "injection-scanner-*-unknown-linux-musl",
@@ -320,4 +369,29 @@ fn glob_matcher_behaves() {
     ));
     assert!(glob_matches("SHA256SUMS.txt", "SHA256SUMS.txt"));
     assert!(!glob_matches("SHA256SUMS.txt", "SHA256SUMS.txt.asc"));
+
+    // A trailing literal that also occurs earlier in the name. The previous
+    // matcher consumed segments left-to-right with `find`, so the middle search
+    // ate the text the tail needed and these all returned false — an asset that
+    // *is* covered by the upload glob reported as uncovered.
+    assert!(glob_matches("a*b", "abxb"));
+    assert!(glob_matches("*-musl", "a-musl-b-musl"));
+    assert!(glob_matches(
+        "injection-scanner-*-unknown-linux-musl",
+        "injection-scanner-x86_64-unknown-linux-musl-unknown-linux-musl"
+    ));
+
+    // Anchors may not overlap: `a*a` needs at least two characters.
+    assert!(!glob_matches("a*a", "a"));
+    assert!(glob_matches("a*a", "aa"));
+
+    // Degenerate patterns.
+    assert!(glob_matches("*", "anything"));
+    assert!(glob_matches("*", ""));
+    assert!(glob_matches("prefix*", "prefix"));
+    assert!(!glob_matches("prefix*", "prefi"));
+
+    // Multiple wildcards, in order.
+    assert!(glob_matches("a*b*c", "a-b-c"));
+    assert!(!glob_matches("a*b*c", "a-c-b"));
 }


### PR DESCRIPTION
Closes #18 — the other half of Phase 2 / T7. The coupling to tool 04 was documented
in a comment block at the top of `release.yml` and checked nowhere.

## Two guards, because they see different failures

**`tests/release_contract_test.rs`** — runs in the ordinary `cargo test` gate, so a
break lands on the PR that causes it. It parses `release.yml` as YAML rather than
grepping it, and asserts the workflow still *produces* the names the consumer
*requests*:

- both musl targets are in the build matrix and **not** `experimental` (an experimental
  leg is `continue-on-error`, so a failure would ship a release missing an asset tool 04
  requires)
- the upload globs still select `injection-scanner-{x86_64,aarch64}-unknown-linux-musl`
  and `SHA256SUMS.txt`
- the attestation `subject-path` still covers them
- the packaging step still emits a raw target-triple-named binary, with no archiving

**`verify-published-assets`** — a new job that runs after the release is published and
walks the consumer's exact path: anonymous `curl` of the public download URL at the new
tag → HTTP 200 → ELF magic → the architecture recorded in the ELF header → present in
`SHA256SUMS.txt` → checksum passes → `--version` runs. A workflow can be perfectly
specified and still fail to upload; that is what this catches and the test cannot.

## Verified by breaking it, not by observing green

Six mutations of `release.yml`, each failing exactly one assertion:

| Mutation | Fails |
|---|---|
| musl target renamed | `musl_targets_are_built_and_are_not_experimental` |
| musl marked `experimental: true` | same |
| upload glob → `.tar.gz` | `published_globs_still_select_the_consumer_assets` |
| packaging → `.tgz` | `assets_are_raw_binaries_named_by_target_triple` |
| musl dropped from `subject-path` | `attestation_covers_the_consumer_assets` |
| verify job removed | `a_published_asset_check_runs_after_the_release` |

The attestation assertion exists **because of a mis-aimed mutation**. The first
occurrence of that glob in the file is the attest step, not the upload step, so the
mutation I intended for the release step hit the attestation instead — and nothing
failed. Nothing had been keeping the two glob lists in step. An asset dropped from
`subject-path` still ships, silently without the provenance the release notes instruct
consumers to verify.

The ELF offsets the job asserts (magic `7f454c46`, `e_machine` `3e00`/`b700`) were
checked against the real published v0.0.2 musl assets, and the run script through
`bash -n`.

## Also

`CONTRIBUTING.md` now states the contract in prose — issue #18 asks for it to be
visible to contributors, not only in a workflow comment — and explains which guard
catches what.

Item 4 of the issue (SHA256 verification in the consumer) shipped separately in
spec-ci-plugin PR #9.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)
