### PR TITLE
fix: the CLI tests were running whatever binary happened to be lying around

### DIFF
--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1,8 +1,22 @@
 use std::process::Command;
 
-fn binary_path() -> String {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    format!("{}/target/debug/injection-scanner", manifest_dir)
+/// The binary Cargo built for *this* test run.
+///
+/// `CARGO_BIN_EXE_<name>` is set by Cargo for integration tests and points at
+/// the artifact it just produced. The previous hard-coded
+/// `target/debug/injection-scanner` was wrong in both directions:
+///
+/// - If that file existed from an earlier `cargo build`, these tests ran **it**
+///   rather than the binary under test. Under `cargo llvm-cov` — which builds
+///   into `target/llvm-cov-target/` — all 14 CLI tests passed against a stale
+///   binary, and `main.rs` measured 0% coverage despite being the only module
+///   these tests exercise.
+/// - If it did not exist, every test panicked with `NotFound`. The suite
+///   depended on an artifact none of it builds.
+///
+/// It also ignored `CARGO_TARGET_DIR`, `--target` and the release profile.
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_injection-scanner")
 }
 
 fn fixture_path(name: &str) -> String {

--- a/tests/pattern_validation_test.rs
+++ b/tests/pattern_validation_test.rs
@@ -11,11 +11,15 @@ use injection_scanner::pattern::{Pattern, PatternCategory, Severity};
 use injection_scanner::patterns::load_embedded_patterns;
 use injection_scanner::scanner::Scanner;
 
-fn binary_path() -> String {
-    format!(
-        "{}/target/debug/injection-scanner",
-        env!("CARGO_MANIFEST_DIR")
-    )
+/// The binary Cargo built for *this* test run.
+///
+/// See the note on the same function in `tests/cli_test.rs`: a hard-coded
+/// `target/debug/injection-scanner` runs whatever artifact happens to be on
+/// disk, so these tests pass against a stale binary under `cargo llvm-cov`
+/// (which builds into `target/llvm-cov-target/`) and panic with `NotFound`
+/// when no earlier `cargo build` left one behind.
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_injection-scanner")
 }
 
 fn temp_dir(name: &str) -> std::path::PathBuf {

--- a/tests/scan_resilience_test.rs
+++ b/tests/scan_resilience_test.rs
@@ -3,11 +3,15 @@
 use std::fs;
 use std::process::Command;
 
-fn binary_path() -> String {
-    format!(
-        "{}/target/debug/injection-scanner",
-        env!("CARGO_MANIFEST_DIR")
-    )
+/// The binary Cargo built for *this* test run.
+///
+/// See the note on the same function in `tests/cli_test.rs`: a hard-coded
+/// `target/debug/injection-scanner` runs whatever artifact happens to be on
+/// disk, so these tests pass against a stale binary under `cargo llvm-cov`
+/// (which builds into `target/llvm-cov-target/`) and panic with `NotFound`
+/// when no earlier `cargo build` left one behind.
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_injection-scanner")
 }
 
 fn temp_dir(name: &str) -> std::path::PathBuf {

--- a/tests/test_harness_contract_test.rs
+++ b/tests/test_harness_contract_test.rs
@@ -1,0 +1,86 @@
+//! Guards the invariant that let 29 tests pass against a binary they never built.
+//!
+//! `tests/cli_test.rs`, `pattern_validation_test.rs` and `scan_resilience_test.rs`
+//! each independently grew a `binary_path()` that formatted
+//! `CARGO_MANIFEST_DIR` + a hard-coded profile directory. Three copies, one bug,
+//! and nothing connected them — so fixing one left the other two.
+//!
+//! The failure mode is silent in the direction that matters. Cargo builds the
+//! binary under test into whatever target directory is in effect, but the tests
+//! invoked a *different* path; if an artifact from some earlier build was
+//! sitting there, they exercised it and reported green. Proven by building a
+//! binary whose entire `main` was `std::process::exit(0)` into an alternate
+//! `CARGO_TARGET_DIR`: all 29 tests passed.
+//!
+//! `env!("CARGO_BIN_EXE_<name>")` is the only correct spelling. Cargo sets it
+//! per integration-test crate and points it at the artifact it just produced,
+//! so it follows `CARGO_TARGET_DIR`, `--target` and the profile for free.
+
+use std::fs;
+use std::path::Path;
+
+/// Assembled at runtime so this file does not match its own rule — the
+/// self-match that bit PI012.
+fn forbidden_fragments() -> Vec<String> {
+    let target = "tar".to_string() + "get";
+    vec![format!("{target}/debug"), format!("{target}/release")]
+}
+
+#[test]
+fn no_integration_test_hard_codes_a_path_into_the_target_directory() {
+    let tests_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let forbidden = forbidden_fragments();
+    let this_file = Path::new(file!())
+        .file_name()
+        .expect("file!() always has a final component")
+        .to_owned();
+
+    let mut offenders = Vec::new();
+    let mut checked = 0usize;
+
+    let entries = fs::read_dir(&tests_dir).expect("tests/ must be readable");
+    for entry in entries {
+        let path = entry.expect("directory entry must be readable").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        if path.file_name() == Some(this_file.as_ref()) {
+            continue;
+        }
+        let source = fs::read_to_string(&path).expect("test source must be valid UTF-8");
+        checked += 1;
+
+        for (index, line) in source.lines().enumerate() {
+            // Prose describing this very rule has to be allowed to name it.
+            // Only executable lines can actually mis-target the binary.
+            if line.trim_start().starts_with("//") {
+                continue;
+            }
+            for fragment in &forbidden {
+                if line.contains(fragment.as_str()) {
+                    offenders.push(format!(
+                        "{}:{}: {}",
+                        path.file_name().and_then(|n| n.to_str()).unwrap_or("?"),
+                        index + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "found no integration tests to check — this guard would pass vacuously"
+    );
+
+    assert!(
+        offenders.is_empty(),
+        "{} integration test source(s) build a path into the target directory \
+         instead of using env!(\"CARGO_BIN_EXE_injection-scanner\"). Such a test \
+         runs whatever artifact is already on disk — it passes against a stale \
+         binary and panics when none exists. Offending lines:\n  {}",
+        offenders.len(),
+        offenders.join("\n  ")
+    );
+}


### PR DESCRIPTION
Found while checking the **">80% coverage on core logic before any release"** constraint that
both CLAUDE.md files state and nothing measures (#29 item 1), ahead of the v0.0.3 tag.

## The bug

`tests/cli_test.rs` built its path by hand:

```rust
format!("{}/target/debug/injection-scanner", env!("CARGO_MANIFEST_DIR"))
```

instead of `env!("CARGO_BIN_EXE_injection-scanner")`, which Cargo sets for integration tests and
points at the artifact it just built. Wrong in both directions:

- **If that file exists** from any earlier `cargo build`, the 14 CLI tests run *it* — not the
  binary under test. Under `cargo llvm-cov`, which builds into `target/llvm-cov-target/`, the
  suite reported `14 passed` while executing stale code.
- **If it doesn't exist**, every test panics. Proven by deleting it:

```
thread 'check_clean_file_exits_zero' panicked at tests/cli_test.rs:23:10:
Failed to execute binary: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

The suite depended on an artifact none of it builds. It also ignored `CARGO_TARGET_DIR`,
`--target`, and the release profile.

`cli_test.rs` is the **only** place `main.rs` is exercised — 130 lines carrying the whole CLI
surface: `--no-suppress`, `--strict-patterns`, `--format`, stdin, the directory walk and its
error isolation. Under plain `cargo test` those tests are fresh by accident of build ordering,
not by construction.

## Measured effect

Same tests, same code — only the attribution changes:

| | Before | After |
|---|---|---|
| `main.rs` | **0.00%** | 60.78% |
| `patterns/mod.rs` | 22.83% | 31.52% |
| **Total regions** | **48.49%** | **72.18%** |
| **Total lines** | 49.62% | 70.38% |

So the repo's real coverage was never 48% — that figure was measuring a stale binary.

## Where that leaves the release gate

Excluding `main.rs` as CLI wiring, **core logic is ~78.8% of regions / 77.7% of lines** — just
under the documented 80%. The whole shortfall sits in one file: `patterns/mod.rs` at 31.52%,
which is `load_external_patterns`, the function that reads untrusted community YAML from a
`--patterns` directory. It has no in-process tests; it is reached only through the CLI.

That is worth knowing before tagging v0.0.3, and it is the natural next piece of #29 —
along with the coverage gate itself, which still does not exist.

Refs #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
