### PR TITLE
fix: actually deny unwrap_used in src/ — the other half of #19

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,39 @@ cargo build --release # optimized binary
 cargo bench          # performance benchmarks (benches/scan.rs)
 ```
 
+### Lints
+
+`cargo clippy -- -D warnings` is the gate, and it covers less than it looks like
+it covers. Clippy's **restriction** group is off by default, and `-D warnings`
+does not turn it on — it only promotes lints that are already firing. So a lint
+in that group catches nothing until something opts into it explicitly.
+
+`clippy::unwrap_used` is the one that bit us. CLAUDE.md has said "no `unwrap()`
+in production code" since the project started, and issue #19 asked for the lint;
+only the cleanup half shipped, so for an entire milestone a new `unwrap()` in
+`src/` passed CI silently. `src/lib.rs` and `src/main.rs` now each carry
+`#![deny(clippy::unwrap_used)]` — both, because they are separate crates and a
+crate-level attribute does not cross that boundary.
+
+Two things to know if you go looking:
+
+- **Testing the gate is easy to get wrong.** `Some(1).unwrap()` is caught even
+  without the attribute, because clippy can see statically that it succeeds.
+  Probe with a value it cannot reason about — `raw.parse::<usize>().unwrap()` —
+  or you will conclude the gate works when it does not.
+- **The same gap applies to every other restriction lint** (`indexing_slicing`,
+  `panic`, `expect_used`, `float_arithmetic`, …). If a rule matters, deny it
+  explicitly; do not assume `-D warnings` is enforcing it.
+
+`expect()` is deliberately *not* denied. It carries a message, and the one use in
+`allowlist.rs` is on a compile-time-constant regex covered by a test — denying it
+there would push toward a silent fallback, which is worse than a documented panic
+on an unreachable branch. If a second `expect()` shows up in `src/`, that is the
+moment to revisit.
+
+Integration tests are separate crates and are unaffected. `unwrap()` in a test is
+fine.
+
 ### Performance
 
 The scanner has a budget of **200ms for a typical project** (500 files). Two things

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,17 @@
+//! Static scanner for prompt-injection patterns in agent-facing documents.
+//!
+//! `unwrap()` is denied crate-wide rather than left to review. CLAUDE.md states
+//! "Do not use `unwrap()` in Rust in production code", and issue #19 asked for
+//! the lint that makes it true; only the `allowlist.rs` cleanup half shipped.
+//! `cargo clippy -- -D warnings` does not catch it on its own — `unwrap_used`
+//! is a restriction lint and is off by default, so a new `unwrap()` in this
+//! crate passed CI silently.
+//!
+//! `expect()` is deliberately NOT denied: it carries a message, and the one use
+//! in `allowlist.rs` is on a compile-time-constant regex covered by a test.
+//! Denying it would push that toward a silent fallback, which is worse.
+#![deny(clippy::unwrap_used)]
+
 pub mod allowlist;
 pub mod pattern;
 pub mod patterns;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
+//! CLI entry point.
+//!
+//! `unwrap()` is denied here as well as in the library — this is a separate
+//! crate, so `lib.rs`'s attribute does not reach it. See the note there.
+#![deny(clippy::unwrap_used)]
+
 use std::fs;
 use std::io::Read;
 use std::path::PathBuf;

--- a/tests/test_harness_contract_test.rs
+++ b/tests/test_harness_contract_test.rs
@@ -84,3 +84,41 @@ fn no_integration_test_hard_codes_a_path_into_the_target_directory() {
         offenders.join("\n  ")
     );
 }
+
+/// Both crate roots must deny `clippy::unwrap_used`.
+///
+/// Issue #19 asked for this and was closed with only its first half done — the
+/// `unwrap()` in `allowlist.rs` was replaced, but nothing was ever configured
+/// to stop the next one. `cargo clippy -- -D warnings` does not cover it:
+/// `unwrap_used` is a restriction lint, off by default, so a new `unwrap()` in
+/// production code passed CI silently for the whole milestone.
+///
+/// The attribute is the enforcement, so removing it is the regression. `src/`
+/// is two crates — the library and the binary — and a crate-level attribute
+/// does not cross that boundary, which is why both are checked.
+#[test]
+fn both_crate_roots_deny_unwrap_used() {
+    use std::fs;
+    use std::path::Path;
+
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let needle = "deny(clippy::unwrap_used)";
+
+    for root in ["lib.rs", "main.rs"] {
+        let path = src.join(root);
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("{} must be readable: {e}", path.display()));
+
+        let declared = source.lines().any(|line| {
+            let line = line.trim();
+            line.starts_with("#![") && line.contains(needle)
+        });
+
+        assert!(
+            declared,
+            "src/{root} does not carry `#![{needle}]`. Without it a new `unwrap()` in \
+             production code passes `cargo clippy -- -D warnings` silently — that lint is \
+             a restriction lint and is off by default. See issue #19."
+        );
+    }
+}


### PR DESCRIPTION
Closes #19 properly.

## The finding

#19 was *"replace `unwrap()` in allowlist.rs **and deny `unwrap_used` in src/**"*. It was closed, and `TODO.md` marks it `[x]`, with only the first half shipped.

Nothing enforced the rule. No `clippy.toml`, no `[lints]` section, no crate-level attribute — and `cargo clippy -- -D warnings` **does not cover it**: `unwrap_used` is a restriction lint, off by default.

Proof, not inference:

```rust
// added to src/reporter.rs
pub fn probe(raw: &str) -> usize { raw.parse::<usize>().unwrap() }
```
```
$ cargo clippy --all-targets -- -D warnings   # exit 0
```

CLAUDE.md has said "Do not use `unwrap()` in Rust in production code" for the entire milestone with nothing behind it.

> A first probe using `Some(1).unwrap()` **was** caught — but only because that is statically detectable, which made the gate look like it worked. Worth knowing if you re-test this.

## The fix

`#![deny(clippy::unwrap_used)]` on both crate roots. `src/` is two crates and a crate-level attribute does not cross that boundary, so `lib.rs` and `main.rs` each need one — verified by adding an `unwrap()` to each and watching clippy fail, and confirming both passed beforehand.

## Deliberate choices — please push back if you disagree

- **`expect()` is not denied.** It carries a message, and the single use (`allowlist.rs:25`) is on a compile-time-constant regex covered by a test. Denying it would push that call toward a silent fallback, which I think is worse than a documented panic on an impossible branch.
- **Attributes, not `[lints]` in Cargo.toml.** `[lints]` applies to every target in the package including `tests/`, where `unwrap()` is entirely appropriate. Crate-root attributes scope it to `src/` exactly, which is what the issue asked for.

## Test

`both_crate_roots_deny_unwrap_used` pins the attributes — removing one is the regression and would otherwise be invisible. Mutation-checked: deleting the attribute from `main.rs` fails it.

`fmt` clean · `clippy -D warnings` clean · 94 tests green