### PR TITLE
fix: make #[serde(default)] on `suppressed` mean something

### DIFF
--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -65,7 +65,7 @@ pub struct PatternCategory {
 }
 
 /// A single match found during scanning.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScanMatch {
     pub pattern_id: String,
     pub pattern_name: String,
@@ -78,7 +78,12 @@ pub struct ScanMatch {
 }
 
 /// Aggregated scan results for a single file.
-#[derive(Debug, Clone, Serialize)]
+///
+/// Round-trips: `--format json` output deserializes back into this type. That
+/// is what makes `#[serde(default)]` on `suppressed` mean anything — without
+/// `Deserialize` the attribute was inert, and the backward-compatibility it
+/// documents could not actually happen.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScanReport {
     pub file: String,
     pub matches: Vec<ScanMatch>,

--- a/tests/report_roundtrip_test.rs
+++ b/tests/report_roundtrip_test.rs
@@ -1,0 +1,98 @@
+//! `ScanReport` must survive a JSON round-trip, and old reports must still load.
+//!
+//! `suppressed` was added with `#[serde(default)]` so that a report written
+//! before the field existed would deserialize with an empty array instead of
+//! failing. That reasoning was sound and the attribute was inert: `ScanReport`
+//! derived `Serialize` only, and `default` affects deserialization exclusively.
+//! Nothing could deserialize a `ScanReport` at all, so the compatibility the
+//! field documented had never been possible.
+
+use injection_scanner::pattern::{ScanMatch, ScanReport, Severity};
+
+fn sample_match(pattern_id: &str) -> ScanMatch {
+    ScanMatch {
+        pattern_id: pattern_id.to_string(),
+        pattern_name: "Instruction override".to_string(),
+        severity: Severity::Critical,
+        message: "Attempts to override agent instructions".to_string(),
+        remediation: "Remove instruction override text.".to_string(),
+        file: "skill.md".to_string(),
+        line: 5,
+        matched_text: "ignore all previous instructions".to_string(),
+    }
+}
+
+#[test]
+fn a_report_survives_a_json_round_trip() {
+    let original = ScanReport::with_suppressed(
+        "skill.md".to_string(),
+        vec![sample_match("PI001")],
+        vec![sample_match("PI003")],
+    );
+
+    let json = serde_json::to_string(&original).expect("report must serialize");
+    let restored: ScanReport = serde_json::from_str(&json).expect("report must deserialize");
+
+    assert_eq!(
+        serde_json::to_value(&original).expect("original to value"),
+        serde_json::to_value(&restored).expect("restored to value"),
+        "a report must survive serialize -> deserialize unchanged"
+    );
+    assert_eq!(restored.matches.len(), 1);
+    assert_eq!(restored.suppressed.len(), 1);
+    assert_eq!(restored.suppressed[0].pattern_id, "PI003");
+    assert_eq!(
+        restored.suppressed[0].matched_text, "ignore all previous instructions",
+        "the suppressed record must keep the evidence, not just the id"
+    );
+}
+
+#[test]
+fn a_report_written_before_suppressed_existed_still_loads() {
+    // Exactly what v0.0.2 emitted: no `suppressed` key at all. This is the case
+    // `#[serde(default)]` was added for and could not previously serve.
+    let legacy = r#"{
+        "file": "skill.md",
+        "matches": [],
+        "critical_count": 0,
+        "high_count": 0,
+        "medium_count": 0,
+        "low_count": 0
+    }"#;
+
+    let restored: ScanReport =
+        serde_json::from_str(legacy).expect("a pre-suppressed report must still deserialize");
+
+    assert!(
+        restored.suppressed.is_empty(),
+        "a missing `suppressed` key must default to empty, not fail the parse"
+    );
+    assert_eq!(restored.file, "skill.md");
+}
+
+#[test]
+fn the_two_arrays_deserialize_into_the_same_shape() {
+    // `--no-suppress` moves a record between the arrays unchanged, so a consumer
+    // must not be able to tell them apart by shape. Tested on the way back in as
+    // well as on the way out.
+    let json = r#"{
+        "file": "skill.md",
+        "matches": [{"pattern_id":"PI001","pattern_name":"n","severity":"CRITICAL",
+                     "message":"m","remediation":"r","file":"skill.md","line":1,
+                     "matched_text":"t"}],
+        "suppressed": [{"pattern_id":"PI001","pattern_name":"n","severity":"CRITICAL",
+                        "message":"m","remediation":"r","file":"skill.md","line":1,
+                        "matched_text":"t"}],
+        "critical_count": 1,
+        "high_count": 0,
+        "medium_count": 0,
+        "low_count": 0
+    }"#;
+
+    let restored: ScanReport = serde_json::from_str(json).expect("must deserialize");
+    assert_eq!(
+        serde_json::to_value(&restored.matches[0]).expect("visible to value"),
+        serde_json::to_value(&restored.suppressed[0]).expect("suppressed to value"),
+        "the two arrays must hold the identical shape"
+    );
+}


### PR DESCRIPTION
## The finding

`ScanReport` derives `Serialize` only. `#[serde(default)]` affects **deserialization exclusively**, so the attribute on `suppressed` was a no-op.

Confirmed by compiling a probe:

```
error[E0277]: the trait bound `ScanReport: serde::Deserialize<'de>` is not satisfied
```

This matters beyond dead code. The field's doc comment — and the review of #55 — both reasoned about behaviour that **could not occur**:

> *"Old JSON consumers that do not know about `suppressed` will ignore it, and deserializing old JSON produces an empty array."*

That was the stated reason the change was backward-compatible. The attribute was advertising a contract the type could not honour, and it read as reassurance during review.

## The fix

Made the contract real rather than deleting the claim: `ScanMatch` and `ScanReport` now derive `Deserialize`, so `--format json` round-trips back into the types that produced it.

## Why derive rather than delete — please challenge this

Deleting `#[serde(default)]` would have been a smaller diff and equally honest. I chose the derive because:

- the JSON is a **published interface** (`spec-ci-plugin` parses it), so a round-trip test is worth having regardless;
- the planned library split (#41) would want it;
- it makes the `matches`/`suppressed` shape symmetry — which `--no-suppress` depends on — assertable on the way *in*, not just out.

The cost is a slightly wider public API surface. If you'd rather keep these output-only, the alternative is a one-line deletion plus a doc-comment correction, and I'll take that instead.

## Tests

Three, all mutation-checked:

1. a full report survives serialize → deserialize unchanged;
2. **a v0.0.2-shaped report with no `suppressed` key still loads**, defaulting to empty — removing the attribute now fails this with `missing field \`suppressed\``, which is what makes the test worth having rather than decorative;
3. `matches` and `suppressed` deserialize into the identical shape.

`fmt` clean · `clippy -D warnings` clean · 97 tests green