### PR TITLE
docs: three SHA pins claimed versions they were not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4.3.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The ACTION is SHA-pinned (supply chain); `toolchain: stable` keeps the
       # Rust version tracking latest stable, which is what we want to test against.
@@ -184,7 +184,7 @@ jobs:
             experimental: true
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust stable + target
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
@@ -343,7 +343,7 @@ jobs:
             artifacts/injection-scanner-*-apple-darwin
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.0
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           # Glob the raw target-triple binaries (NOT the .sha256 sidecars) + the
           # aggregate manifest. Raw binaries have no extension; exclude *.sha256.


### PR DESCRIPTION
## The finding

Every action is SHA-pinned with a trailing `# vX.Y.Z`. That comment is the only human-readable statement of what is pinned — the entire reason the convention exists. Three of seven were wrong:

| file | action | comment said | actually is |
|---|---|---|---|
| `ci.yml` | `actions/checkout` | v4.3.0 | **v7.0.1** |
| `release.yml` | `actions/checkout` | v5.0.0 | **v7.0.1** |
| `release.yml` | `softprops/action-gh-release` | v3.0.0 | **v3.0.2** |

What made it visible: the *same* checkout SHA carried two *different* version comments in two files. They cannot both be right, and neither was.

Cause: dependabot updates the digest and leaves the comment. #49's own diff changes the SHA and keeps `# v4.3.0`:

```diff
-uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4.3.0
```

## Severity: low, and I want to be clear about why

**No security impact.** The digest is what Actions enforces; the comment is inert. Every pin resolves to a version at or *newer* than claimed, so nothing was running old code.

The cost is auditability. A reviewer reading `# v4.3.0` concludes the repo is two majors behind on checkout. And once some comments are known wrong, none of them can be trusted — which defeats the point of pinning-with-annotation in a repo that made SHA-pinning a deliberate supply-chain decision.

## Verification

All seven tags resolved through the GitHub API, annotated tags dereferenced to their commits, compared against the pinned digests:

```
OK    release.yml  actions/attest-build-provenance@v4.2.2
OK    ci.yml       actions/cache@v6.1.0
OK    ci.yml       actions/checkout@v7.0.1
OK    release.yml  actions/checkout@v7.0.1
OK    release.yml  actions/download-artifact@v8.0.1
OK    release.yml  actions/upload-artifact@v7.0.1
OK    release.yml  softprops/action-gh-release@v3.0.2

all pins agree with their comments
```

## Open question for review

I did **not** add a CI check for this, because verifying comment↔SHA agreement needs network calls to the GitHub API and would make the test suite network-dependent and flaky. A `workflow_dispatch` audit job, or accepting that this recurs on every dependabot bump, both seem defensible. Opinions welcome.

Comments only — no behaviour change.