### PR TITLE
feat: rebalance severity across the full range (#21)

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -27,6 +27,40 @@ patterns:
 | Jailbreaks | PI030-PI039 | HIGH |
 | Encoding/Obfuscation | PI040-PI049 | HIGH |
 
+## Grading Severity
+
+Every pattern in the library used to be CRITICAL or HIGH — 14 and 16, with no
+MEDIUM and no LOW anywhere. Everything was an emergency, so nothing was, and
+`--fail-on <severity>` had nothing meaningful to threshold on.
+
+Grade against **how much benign text shares the phrasing**, not against how bad
+the attack would be if real. Every pattern here describes a bad outcome; that is
+not what separates them.
+
+| Severity | Test | Examples |
+|---|---|---|
+| **CRITICAL** | No plausible benign reading. If this string is in a document, something is wrong. | `ignore all previous instructions`, `[SYSTEM OVERRIDE]`, `send the following to https://…`, a run of zero-width characters |
+| **HIGH** | Strong signal; benign use is rare and usually deliberate. | `DAN mode`, `developer mode enabled`, `your real purpose is`, `bypass the content filter` |
+| **MEDIUM** | Suspicious in context, but ordinary documents genuinely say this. | `you are now …`, `New task:`, `fetch https://…`, `in this hypothetical scenario where you …` |
+| **LOW** | A heuristic or a weak signal. Names a concept, or could be an artefact. | `jailbreak prompt` (the term, not a payload), a single zero-width character |
+
+Three rules that decide most cases:
+
+1. **Naming is not carrying.** A pattern that matches a *term* — `jailbreak
+   prompt`, `DAN` — fires on every security write-up that discusses the
+   technique, this repository's own documentation included. That is LOW or
+   MEDIUM, never CRITICAL.
+2. **One is an artefact, several are intent.** A single zero-width character
+   arrives from a word processor or a copied web page. A run of three is
+   deliberate. `PI041` is LOW and `PI042` is CRITICAL for exactly this reason.
+3. **If you had to imagine the benign case, it is not CRITICAL.** If you can
+   recall a real document that would match, it is MEDIUM at most.
+
+Grades are enforced two ways. `tests/pattern_test.rs` asserts every level stays
+populated, so the library cannot silently drift back to all-CRITICAL. And
+`tests/corpus/clean/` holds real documents that must produce **zero** findings —
+if your pattern fires there, the grade is not the problem.
+
 ## Submitting a Pattern
 
 1. Fork the repo

--- a/patterns/core/encoding.yaml
+++ b/patterns/core/encoding.yaml
@@ -3,12 +3,20 @@ default_severity: HIGH
 patterns:
   - id: PI040
     name: unicode-rtl-override
+    # MEDIUM: Lumps explicit overrides (U+202D/E) with the LRM/RLM marks that every
+    # Arabic and Hebrew document uses legitimately. Splitting the two is worth
+    # doing and needs a new ID, so it belongs with #27 rather than here.
+    severity: MEDIUM
     pattern: "\\x{202E}|\\x{202D}|\\x{202C}|\\x{200F}|\\x{200E}"
     description: "Unicode direction override character — can hide text direction"
     remediation: "Remove Unicode direction override characters. These make text visually misleading."
     tags: [encoding, unicode]
   - id: PI041
     name: zero-width-chars
+    # LOW: One zero-width character. Deliberate obfuscation is a RUN of them,
+    # which PI042 reports at CRITICAL. A single one is more often a paste
+    # artefact from a word processor or a web page.
+    severity: LOW
     pattern: "\\x{200B}|\\x{FEFF}|\\x{200C}|\\x{200D}"
     description: "Zero-width characters — can hide instructions invisible to humans"
     remediation: "Remove zero-width characters. These can hide instructions that LLMs still process."

--- a/patterns/core/exfiltration.yaml
+++ b/patterns/core/exfiltration.yaml
@@ -33,8 +33,10 @@ patterns:
     tags: [exfiltration]
   - id: PI025
     name: fetch-url
+    # MEDIUM: Documentation says "fetch https://api.example.com" constantly. A URL
+    # fetch may be the whole point of the tool being documented.
+    severity: MEDIUM
     pattern: "fetch\\s+https?://[^\\s]+"
-    severity: HIGH
     description: "External URL fetch request"
     remediation: "Review URL fetch — may be legitimate or exfiltration vector."
     tags: [exfiltration, url]

--- a/patterns/core/instruction-injection.yaml
+++ b/patterns/core/instruction-injection.yaml
@@ -3,6 +3,8 @@ default_severity: HIGH
 patterns:
   - id: PI010
     name: new-task-injection
+    # MEDIUM: Every ticket template and to-do list literally begins "New task:".
+    severity: MEDIUM
     pattern: "(?i)^\\s*new\\s+task\\s*:"
     description: "Injected task instruction"
     remediation: "Remove injected task. Legitimate tasks should use proper skill format."
@@ -41,6 +43,9 @@ patterns:
     tags: [injection]
   - id: PI014
     name: developer-wants
+    # MEDIUM: Hit as a false positive in this project's own planning docs, in prose
+    # describing agent behaviour.
+    severity: MEDIUM
     pattern: "the\\s+developer\\s+wants\\s+you\\s+to"
     description: "Authority impersonation via developer claim"
     remediation: "Remove false developer attribution."

--- a/patterns/core/jailbreak.yaml
+++ b/patterns/core/jailbreak.yaml
@@ -27,14 +27,19 @@ patterns:
     tags: [jailbreak]
   - id: PI034
     name: hypothetical-scenario
+    # MEDIUM: Fiction, teaching material and threat modelling all frame things
+    # hypothetically.
+    severity: MEDIUM
     pattern: "in\\s+this\\s+hypothetical\\s+scenario\\s+where\\s+you\\s+can"
     description: "Hypothetical scenario jailbreak"
     remediation: "Remove hypothetical bypass framing."
     tags: [jailbreak]
   - id: PI035
     name: jailbreak-prompt  # injection-scanner:ignore PI035
+    # LOW: Names the concept rather than carrying a payload. Any security
+    # write-up, this repo's own docs included, discusses jailbreak prompts.
+    severity: LOW
     pattern: "(?i)\\bjailbreak\\s+prompt\\b"
-    severity: CRITICAL
     description: "Explicit jailbreak prompt reference"  # injection-scanner:ignore PI035
     remediation: "Remove jailbreak prompt."  # injection-scanner:ignore PI035
     tags: [jailbreak]
@@ -52,6 +57,8 @@ patterns:
     tags: [jailbreak]
   - id: PI038
     name: unlimited-mode  # injection-scanner:ignore PI038
+    # MEDIUM: "Unlimited mode" is a subscription tier as often as it is a jailbreak.
+    severity: MEDIUM
     pattern: "(?i)unlimited\\s+mode"
     description: "Unrestricted mode activation"
     remediation: "Remove unlimited mode activation."  # injection-scanner:ignore PI038

--- a/patterns/core/role-override.yaml
+++ b/patterns/core/role-override.yaml
@@ -15,8 +15,11 @@ patterns:
     tags: [role-override]
   - id: PI003
     name: you-are-now
+    # MEDIUM: "You are now ready to proceed" / "you are now on call" — the
+    # phrasing is ordinary English. Role reassignment needs the surrounding
+    # intent, which a regex does not have.
+    severity: MEDIUM
     pattern: "you\\s+are\\s+now\\s+\\w+"
-    severity: HIGH
     description: "Role reassignment attempt"
     remediation: "Remove role override. Use explicit skill scoping instead."
     tags: [role-override]
@@ -34,6 +37,9 @@ patterns:
     tags: [role-override]
   - id: PI006
     name: forget-everything
+    # HIGH: "Forget everything you know about X" is a teaching device. Strong
+    # signal, but not the no-benign-reading bar CRITICAL asks for.
+    severity: HIGH
     pattern: "forget\\s+everything\\s+you\\s+know"
     description: "Memory wipe attempt"
     remediation: "Remove memory wipe instruction."

--- a/tests/pattern_test.rs
+++ b/tests/pattern_test.rs
@@ -30,12 +30,23 @@ fn test_severity_override() {
         .iter()
         .find(|c| c.category == "role_override")
         .unwrap();
-    let pi003 = role_override
+    // Asserts the MECHANISM, not a grade. This pinned `PI003 == High` and broke
+    // when #21 regraded it to MEDIUM — the override was working perfectly. What
+    // must hold is that a per-pattern severity is parsed and differs from the
+    // category default; which pattern demonstrates that is a detail of the
+    // library, not of the loader.
+    let overridden: Vec<_> = role_override
         .patterns
         .iter()
-        .find(|p| p.id == "PI003")
-        .unwrap();
-    assert_eq!(pi003.severity, Some(Severity::High));
+        .filter_map(|p| p.severity.map(|s| (p.id.as_str(), s)))
+        .filter(|(_, s)| *s != role_override.default_severity)
+        .collect();
+    assert!(
+        !overridden.is_empty(),
+        "at least one role_override pattern must override the category default \
+         of {:?}, or this test proves nothing",
+        role_override.default_severity
+    );
 }
 
 #[test]
@@ -76,4 +87,47 @@ fn test_all_patterns_have_remediation() {
             );
         }
     }
+}
+
+/// The whole severity range stays populated (#21, QUAL-02).
+///
+/// The library shipped 30 patterns graded 14 CRITICAL / 16 HIGH, with no MEDIUM
+/// and no LOW anywhere. Everything was an emergency, so nothing was, and
+/// `--fail-on <severity>` had no meaningful threshold to offer.
+///
+/// The pressure runs one way — a new pattern's author believes in it, and the
+/// category defaults are CRITICAL and HIGH — so without this the distribution
+/// drifts back on its own.
+#[test]
+fn every_severity_level_is_populated() {
+    use std::collections::BTreeMap;
+
+    let categories = injection_scanner::patterns::load_embedded_patterns().expect("patterns");
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for category in &categories {
+        for pattern in &category.patterns {
+            let severity = pattern.severity.unwrap_or(category.default_severity);
+            *counts.entry(format!("{severity:?}")).or_default() += 1;
+        }
+    }
+
+    for level in ["Critical", "High", "Medium", "Low"] {
+        assert!(
+            counts.get(level).copied().unwrap_or(0) > 0,
+            "no {level} patterns exist. A scanner whose every finding is an \
+             emergency has no findings — see the grading criteria in \
+             PATTERNS.md. Distribution: {counts:?}"
+        );
+    }
+
+    // Nothing here is a target; the bound only catches a wholesale slide back to
+    // "everything is CRITICAL", which is the failure this guards.
+    let total: usize = counts.values().sum();
+    let critical = counts.get("Critical").copied().unwrap_or(0);
+    assert!(
+        critical * 2 <= total,
+        "{critical} of {total} patterns are CRITICAL. Grade against how much \
+         benign text shares the phrasing, not against how bad the attack would \
+         be — every pattern here describes a bad outcome. See PATTERNS.md."
+    );
 }


### PR DESCRIPTION
Closes #21 (QUAL-02). **Unblocks CLI-06** — the issue notes `--fail-on <severity>` is meaningless until the distribution is real.

Thirty patterns graded **14 CRITICAL / 16 HIGH / 0 MEDIUM / 0 LOW**. Everything was an emergency, so nothing was.

Now **12 / 9 / 7 / 2**.

## The criteria, written into PATTERNS.md

Grade against **how much benign text shares the phrasing**, not how bad the attack would be if real. Every pattern here describes a bad outcome — that isn't what separates them.

| Severity | Test |
|---|---|
| **CRITICAL** | No plausible benign reading |
| **HIGH** | Strong signal; benign use rare and deliberate |
| **MEDIUM** | Suspicious in context, but ordinary documents genuinely say this |
| **LOW** | A heuristic. Names a concept, or could be an artefact |

Three rules that decide most cases:

1. **Naming is not carrying.** A pattern matching a *term* — `jailbreak prompt`, `DAN` — fires on every security write-up discussing the technique, this repo's own docs included.
2. **One is an artefact, several are intent.** A single zero-width character comes from a word processor; a run of three is deliberate. `PI041` → LOW, `PI042` stays CRITICAL.
3. **If you had to imagine the benign case, it isn't CRITICAL.**

## Demotions, with evidence

Every one carries its justification inline in the YAML. Several are documented false positives rather than hypotheticals:

| | | Why |
|---|---|---|
| `PI014` the developer wants you to | HIGH → MEDIUM | Hit in this project's own planning docs |
| `PI025` fetch URL | HIGH → MEDIUM | Any documentation saying `fetch https://api.example.com` |
| `PI035` jailbreak prompt | CRITICAL → **LOW** | Names the concept; carries no payload |
| `PI041` single zero-width char | HIGH → **LOW** | Paste artefact more often than obfuscation |
| `PI040` bidi override | HIGH → MEDIUM | Lumps explicit overrides with the LRM/RLM marks every Arabic and Hebrew document uses. Splitting needs a new ID → belongs with #27 |
| `PI003` you are now … | HIGH → MEDIUM | "You are now ready to proceed" |
| `PI010` New task: | HIGH → MEDIUM | Every ticket template begins this way |
| `PI034` hypothetical scenario | HIGH → MEDIUM | Fiction, teaching, threat modelling |
| `PI038` unlimited mode | HIGH → MEDIUM | A subscription tier as often as a jailbreak |
| `PI006` forget everything you know | CRITICAL → HIGH | "…about X" is a teaching device |

## Guarded, because the pressure runs one way

A new pattern's author believes in it, and both category defaults are CRITICAL or HIGH — so the distribution drifts back on its own. A test asserts every level stays populated and that CRITICAL never exceeds half the library. Mutation-checked by promoting both LOW patterns:

```
no Low patterns exist. A scanner whose every finding is an emergency has no
findings — see the grading criteria in PATTERNS.md.
Distribution: {"Critical": 14, "High": 9, "Medium": 7}
```

## Also fixes a test that was fragile by construction

`test_severity_override` pinned `PI003 == High` as a proxy for "severity override works". The override was working perfectly; the test broke because the *grade* changed. It now asserts the mechanism — that some pattern overrides its category default — which is the invariant that was meant.

Real-world effect, eight-repo tree: `48 findings: 17 critical, 16 high, 15 medium` — previously all 48 were critical or high.

Full suite **22 binaries green**, clippy clean.