### PR TITLE
feat: --baseline for incremental adoption, and install-hook --baseline (#25, CLI-08)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,7 +6,7 @@ See: `.planning/PROJECT.md`
 **Milestone:** Production Readiness — v0.0.3 + v0.1.0 (opened 2026-08-21)
 
 ## Current Phase
-**Phase 4 — Integration (v0.1.0)** · status: **Phase 3 complete; the adoption POC is in**
+**Phase 4 — Integration (v0.1.0)** · status: **CLI-08 `--baseline` landed; 6 items remain**
 
 `main` is green — fmt, clippy, 24 test binaries — and still strictly linear.
 
@@ -42,15 +42,23 @@ HTML comment. Both are caught, at 60ms on a 40-file repo against a 200ms budget.
 | 1 | Restore the Gate | ✅ Merged (PR #44) |
 | 2 | Correctness — ship v0.0.3 | ✅ Shipped 2026-08-23 |
 | 3 | Signal Quality | ✅ Complete — QUAL-01/02/03, SCAN-05/06, CLI-09/10 |
-| 4 | Integration — ship v0.1.0 | 🔄 In progress — HOOK-01, CLI-06, CLI-07 done |
+| 4 | Integration — ship v0.1.0 | 🔄 In progress — HOOK-01, CLI-06, CLI-07, CLI-08 done |
 
-### Phase 4 remaining (7)
-CLI-04 SARIF · CLI-08 `--baseline` · PERF-02 Aho-Corasick · SCAN-07 patterns (PR #66, awaiting
-contributor) · TEST-01 coverage gate · TEST-02 criterion benchmarks · DOCS-02 (partly done — the
-severity criteria landed with #21; the per-pattern test policy is #70)
+### Phase 4 remaining (6)
+CLI-04 SARIF · PERF-02 Aho-Corasick · SCAN-07 patterns (PR #66, awaiting contributor) ·
+TEST-01 coverage gate · TEST-02 criterion benchmarks · DOCS-02 (partly done — the severity
+criteria landed with #21; the per-pattern test policy is #70)
 
-**Next:** CLI-08 `--baseline` is the highest-value remaining adoption feature — an existing
-repository cannot adopt this without it, because day one is a wall of findings.
+**Next:** CLI-04 SARIF is the last unmet *original* v0.0.1 promise still in this phase's success
+criteria ("validates against the 2.1.0 schema and uploads to GitHub code scanning"), and `--format
+sarif` silently returning text is the audit finding that opened this milestone. TEST-01's coverage
+gate is the alternative — the ">80% on core logic" constraint both CLAUDE.md files state is met at
+~92% but still ungated, so nothing stops it regressing.
+
+## Quick Tasks Completed
+| Task | Requirement | Branch | Result |
+|---|---|---|---|
+| `260825-tc7` `--baseline` | CLI-08 | `feat/cli-08-baseline` | 3 commits, 196 tests green, not yet PR'd |
 
 ## Releases
 - **v0.0.1** (2026-04-01): 30 patterns, 5 categories, text/JSON output, inline suppression, stdin mode
@@ -97,6 +105,32 @@ log; an independent reviewer's `gh api orgs/UnityInFlow/actions/runner-groups` r
 org-admin rights. The Phase 1 design is correct either way, but someone with org admin should confirm.
 
 ## Session Notes
+- 2026-08-25: **CLI-08 `--baseline` shipped** on `feat/cli-08-baseline` (3 commits, 196 tests, fmt +
+  clippy clean). Two flags: `--write-baseline <FILE>` accepts the current state and exits 0 by
+  design; `--baseline <FILE>` moves accepted findings into a **fourth** withheld array,
+  `ScanReport.baselined`, alongside `suppressed` and `low_confidence`. Same rule as those two:
+  filed under the reason they are withheld, never dropped.
+  **The design decision worth carrying forward is why the payload is hashed rather than stored.**
+  `json` is in `DEFAULT_EXTENSIONS`, so a committed `baseline.json` holding verbatim payloads would
+  be flagged by the very next scan — the adoption artifact would become a finding source. Confirmed
+  live, not just in a test: `check . --baseline b.json` scans `./b.json` as its own report and finds
+  nothing. Hashing also closes a real attack, since the adversary authors the scanned text and a
+  weak digest would let a *new* payload be tuned onto an already-accepted fingerprint. Identity is
+  `(file, pattern_id, sha256(matched_text))` — **line number deliberately excluded**, so editing
+  above a finding does not force regeneration, plus an occurrence `count` so baselining two
+  occurrences accepts two and not an unlimited number. Cost accepted: a PR reviewer sees
+  `PI001 in docs/foo.md ×2`, not the text. Recorded in `docs/adr/ADR-002-baseline-fingerprints.md`.
+  Verified independently of the executor's report, against the real binary: doubling a payload past
+  its `count` still exits 1; a stale entry is named on stderr and exits 0; malformed, unknown-version
+  and missing baselines are hard errors; both flags together and `--write-baseline` with `check -`
+  are rejected, the latter before stdin is read and without creating the file; `--format json` still
+  parses as `Vec<ScanReport>` with the baselined record carrying full evidence.
+  **Two process notes.** (1) The executor ran in an isolated worktree and the merge-back helper
+  produced a **merge commit**, which contradicts this repo's strictly-linear history — flattened to
+  the three commits before committing anything. Check this on every worktree-isolated task.
+  (2) Task 2's adversarial tests **passed on first run**, because Task 1 built the complete slice
+  rather than the minimum. They are real tests but they never failed first, so they are weaker
+  evidence than the plan intended; the behaviours were re-proven by hand against the binary instead.
 - 2026-08-22 (later): Review round on the four open PRs, then all nine merged. The blocking finding
   — `suppression_trust_test.rs` still hand-building its binary path — turned out to be **three**
   files, not one: `pattern_validation_test.rs` and `scan_resilience_test.rs` were already on `main`

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -58,7 +58,7 @@ gate is the alternative — the ">80% on core logic" constraint both CLAUDE.md f
 ## Quick Tasks Completed
 | Task | Requirement | Branch | Result |
 |---|---|---|---|
-| `260825-tc7` `--baseline` | CLI-08 | `feat/cli-08-baseline` | 3 commits, 196 tests green, not yet PR'd |
+| `260825-tc7` `--baseline` | CLI-08 | `feat/cli-08-baseline` | 5 commits, 203 tests green, reviewed + fixed, not yet PR'd |
 
 ## Releases
 - **v0.0.1** (2026-04-01): 30 patterns, 5 categories, text/JSON output, inline suppression, stdin mode
@@ -105,6 +105,29 @@ log; an independent reviewer's `gh api orgs/UnityInFlow/actions/runner-groups` r
 org-admin rights. The Phase 1 design is correct either way, but someone with org admin should confirm.
 
 ## Session Notes
+- 2026-08-25 (review): Reviewed the CLI-08 diff against the repo's Rust checklist and found one
+  blocking issue the tests could not have caught, because no test crossed the two features.
+  **`--baseline` and `install-hook` did not compose.** The generated hook hardcodes
+  `check . --fail-on <bar> --no-ignore`; there was no way to pass a baseline. Reproduced end to
+  end: a repo that adopts a baseline, then installs the hook, cannot commit at all — the exact wall
+  CLI-08 exists to remove, rebuilt one layer down. The README made it worse by name-dropping the
+  hook in the baseline section ("exactly how the installed pre-commit hook invokes the scanner"),
+  so the docs promised an integration that did not exist. `install-hook --baseline` now exists, the
+  path is canonicalised at install time (the hook scans from a temp staging copy, so a relative path
+  would resolve there and not exist) and an unresolvable path is refused at install rather than on
+  someone's next commit. Three smaller fixes: `--write-baseline` was jumping over the
+  "N file(s) skipped and NOT scanned" summary; `Baseline` lacked the `deny_unknown_fields` that
+  `BaselineEntry` carries on the identical rationale; duplicate identities overwrote instead of
+  summing. 203 tests.
+  **Carry forward — the security property that actually mattered held, and it was worth checking.**
+  `digest` is over `matched_text`, which `scanner.rs` sets from `original_slice` — the ORIGINAL
+  bytes, not the normalized form. Verified live: baseline an ASCII payload, swap one `o` for
+  Cyrillic `о`, and it still exits 1. Had `matched_text` been the normalized text, every baselined
+  finding would have become a free pass for its whole obfuscation family. Any future feature that
+  keys on `matched_text` needs this same check.
+  **Carry forward — the gap was at a feature seam, and green tests hid it.** Both features were
+  individually well tested; nothing exercised them together. HOOK-01 shipped one task earlier and
+  CLI-08 the next, and neither task's plan owned the seam.
 - 2026-08-25: **CLI-08 `--baseline` shipped** on `feat/cli-08-baseline` (3 commits, 196 tests, fmt +
   clippy clean). Two flags: `--write-baseline <FILE>` accepts the current state and exits 0 by
   design; `--baseline <FILE>` moves accepted findings into a **fourth** withheld array,

--- a/.planning/quick/260825-tc7-cli-08-implement-baseline-file-for-incre/260825-tc7-CONTEXT.md
+++ b/.planning/quick/260825-tc7-cli-08-implement-baseline-file-for-incre/260825-tc7-CONTEXT.md
@@ -1,0 +1,72 @@
+# Context — CLI-08 `--baseline`
+
+**Locked by the user 2026-08-25. Do not revisit these; plan against them.**
+
+Requirement: `.planning/REQUIREMENTS.md` **CLI-08** — "`--baseline <file>` for incremental
+adoption on an existing repository". GitHub issue **#25** (last open item on it; `--fail-on`,
+`--quiet`, exit 2, `rules`, `explain` already shipped in PR #76). Phase 4, `.planning/ROADMAP.md`.
+
+Issue #25 calls `--baseline` "the single highest-value adoption feature here". STATE.md agrees:
+"an existing repository cannot adopt this without it, because day one is a wall of findings."
+
+## D-1 — Fingerprint: hashed payload + occurrence count
+
+An entry identifies an accepted finding by:
+
+| field | role |
+|---|---|
+| `file` | repo-relative path as the scanner reports it |
+| `pattern_id` | e.g. `PI001` |
+| `digest` | `sha256:<hex>` over the **matched text** |
+| `count` | how many occurrences of this exact fingerprint were accepted |
+| `first_seen_line` | informational only — **not** part of identity |
+
+**Line numbers are deliberately excluded from identity.** Editing anything above a finding must
+not invalidate the baseline, or the baseline needs regenerating on every commit and stops being
+a record of a decision.
+
+**The payload is hashed, not stored verbatim, for a specific reason:** `json` is in
+`DEFAULT_EXTENSIONS` (`src/walk.rs`), so a committed `baseline.json` full of verbatim payloads
+would itself be flagged by the next scan — the adoption artifact would become a finding source.
+Hashing makes the baseline inert. It also removes any crafted-collision surface: the adversary
+authors the scanned text, and a weak/non-cryptographic digest would let a *new* payload be
+tuned to match an already-accepted fingerprint.
+
+`count` closes the "more of the same is free" hole: baselining two occurrences accepts two, not
+an unlimited number. A third identical occurrence is reported.
+
+Cost accepted: a reviewer reading the baseline in a PR sees `PI001 in docs/foo.md ×2`, not the
+text. That is the trade the user chose.
+
+New dependency: `sha2 = "0.10"`.
+
+## D-2 — Creation and reporting
+
+- `check --write-baseline <FILE>` — scan, write the baseline, exit `0` (`exit::CLEAN`). This is
+  "accept the current state".
+- `check --baseline <FILE>` — findings whose fingerprint is in the file are moved out of
+  `matches` into a **new `baselined: Vec<ScanMatch>` array** on `ScanReport` and do not affect
+  the exit code.
+- `--baseline` and `--write-baseline` are **mutually exclusive** (clap `conflicts_with`).
+- **Nothing is dropped.** `baselined` is a fourth array alongside the existing `matches`,
+  `suppressed` and `low_confidence`, and follows their established rationale verbatim: a finding
+  withheld is filed under *the reason* it is withheld, never discarded. Text output gets a
+  one-line count, in the same voice as the existing suppression / low-confidence lines.
+- **Stale entries are reported.** Baseline entries that matched nothing this run are surfaced as
+  a note so the baseline can be pruned — a stale entry is a live licence to re-introduce the
+  finding it once accepted.
+
+## Non-negotiable constraints carried in from the repo
+
+- `baselined` is an **additive** field with `#[serde(default)]`. The top-level JSON must stay an
+  **array of report objects** — `spec-ci-plugin` does `JSON.parse(output) as Array<...>`. This is
+  the same constraint that shaped `suppressed` and `low_confidence`; the audit's L-02 JSON
+  envelope is still deferred.
+- Severity tallies (`critical_count` etc.) count `matches` **only**, so a baselined finding must
+  not be counted. Match the existing `with_withheld` construction rather than inventing a path.
+- `#![deny(clippy::unwrap_used)]` is in force in both crates. No `unwrap()`.
+- A malformed or missing baseline file is a **hard error**, not a silent no-op.
+- `--write-baseline` against stdin (`check -`) has no meaningful file identity — reject it.
+- Tests: integration tests MUST use `env!("CARGO_BIN_EXE_injection-scanner")`. Hand-building a
+  path into the target directory is forbidden and `tests/test_harness_contract_test.rs` enforces
+  it — see the 2026-08-22 session note in STATE.md for why.

--- a/.planning/quick/260825-tc7-cli-08-implement-baseline-file-for-incre/260825-tc7-PLAN.md
+++ b/.planning/quick/260825-tc7-cli-08-implement-baseline-file-for-incre/260825-tc7-PLAN.md
@@ -1,0 +1,305 @@
+---
+phase: quick-260825-tc7
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - Cargo.toml
+  - src/lib.rs
+  - src/baseline.rs
+  - src/pattern.rs
+  - src/reporter.rs
+  - src/main.rs
+  - tests/baseline_test.rs
+  - tests/report_roundtrip_test.rs
+  - README.md
+  - docs/adr/ADR-002-baseline-fingerprints.md
+autonomous: true
+requirements: [CLI-08]
+user_setup: []
+
+estimate:
+  tokens: 85000
+  raw_tokens: 85000
+  tasks: 3
+  confidence: low
+
+must_haves:
+  truths:
+    - "`check <path> --write-baseline <FILE>` scans, writes FILE, and exits 0 even with CRITICAL findings (D-2)"
+    - "`check <path> --baseline <FILE>` moves every finding whose fingerprint is in FILE out of `matches` into `baselined`, and exits 0 (D-2)"
+    - "A baselined finding is NOT counted in `critical_count`/`high_count`/`medium_count`/`low_count` and does NOT affect the exit code (D-2)"
+    - "An occurrence beyond an entry's `count` is still reported in `matches` and still fails the build (D-1)"
+    - "A baseline entry that matched nothing this run is surfaced as a prunable-stale note (D-2)"
+    - "A missing, unreadable, malformed, or unknown-version baseline file is a hard error — never a silent no-op"
+    - "`--baseline` and `--write-baseline` together are rejected by clap; `--write-baseline` with `check -` is rejected before stdin is read (D-2)"
+    - "The written baseline is inert: scanning it with the scanner produces zero findings, because payloads are stored as `sha256:<hex>` and never verbatim (D-1)"
+    - "Editing lines above a finding does not invalidate its baseline entry — line number is not part of identity (D-1)"
+    - "`--format json` top level is still a bare array of report objects"
+  artifacts:
+    - src/baseline.rs
+    - "src/pattern.rs — `ScanReport.baselined` + `ScanReport::with_baselined`"
+    - "src/reporter.rs — baselined note in `format_text`"
+    - "src/main.rs — `--baseline` / `--write-baseline` on `Commands::Check`"
+    - tests/baseline_test.rs
+    - docs/adr/ADR-002-baseline-fingerprints.md
+    - "README.md — `## Adopting On An Existing Repository` section"
+  key_links:
+    - "`with_baselined` is the only constructor that recomputes the severity tallies — a baselined finding must move through it, not be spliced into an already-built report"
+    - "`format_text`'s zero-total branch must print `No injection patterns reported.` (not `detected`) when `baselined` is non-empty, matching the existing suppressed/low_confidence rule"
+    - "clap `conflicts_with` between `--baseline` and `--write-baseline` — the mutual exclusion is declared, not hand-checked"
+    - "the `file` key is normalised by stripping one leading `./`, so a baseline written by `check .` (which is exactly how the installed pre-commit hook invokes the scanner) matches one consumed by `check docs/foo.md`"
+    - "`serde(default)` on `baselined` — a report emitted by v0.0.3 must still deserialize"
+---
+
+<objective>
+Implement CLI-08 — `--baseline <FILE>` and `--write-baseline <FILE>` — so an existing repository
+can adopt the scanner without day one being a wall of findings.
+
+Purpose: STATE.md names this the highest-value remaining adoption feature; issue #25 calls it
+"the single highest-value adoption feature here". It is the last open item on #25.
+
+Output: a `baseline` module, a fourth withheld-findings array on `ScanReport`, two CLI flags, a
+reporter note, an integration test file, an ADR, and a README section.
+
+## The baseline file
+
+A JSON **object** (this is a new artifact, not the report stream — the report stream's
+array-at-top-level contract is untouched):
+
+- `version` — u32, currently `1`. An unrecognised version is a hard error.
+- `generated_by` — string, `#[serde(default)]`, set to the crate name + `CARGO_PKG_VERSION`.
+- `entries` — array of entry objects, each `#[serde(deny_unknown_fields)]`:
+  - `file` — repo-relative path as the scanner reports it, with one leading `./` stripped
+  - `pattern_id` — e.g. `PI001`
+  - `digest` — `sha256:` followed by 64 lowercase hex chars, over the bytes of `matched_text`
+  - `count` — usize, how many occurrences of this exact fingerprint were accepted
+  - `first_seen_line` — usize, `#[serde(default)]`, informational only, NOT part of identity
+
+Identity is the triple `(file, pattern_id, digest)`. Line numbers are deliberately excluded: per
+D-1, editing anything above a finding must not invalidate the baseline.
+
+## Locked decisions being implemented
+
+- **D-1** — hashed payload (`sha2 = "0.10"`, sha256) plus occurrence `count`; line excluded from
+  identity. Hashing is what keeps the committed baseline inert, since `json` is in
+  `DEFAULT_EXTENSIONS`, and removes the crafted-collision surface.
+- **D-2** — `--write-baseline` writes and exits `exit::CLEAN`; `--baseline` moves findings into a
+  new `baselined: Vec<ScanMatch>`; the two flags are mutually exclusive; nothing is dropped; stale
+  entries are reported.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@.planning/quick/260825-tc7-cli-08-implement-baseline-file-for-incre/260825-tc7-CONTEXT.md
+@CLAUDE.md
+@src/pattern.rs
+@src/reporter.rs
+@src/main.rs
+@tests/report_roundtrip_test.rs
+@tests/suppression_symmetry_test.rs
+@tests/cli_surface_test.rs
+@.claude/skills/code-review/SKILL.md
+@.claude/skills/pr-artifacts/SKILL.md
+</context>
+
+<tasks>
+
+<task type="tracer" tdd="true">
+  <name>Task 1: One accepted finding, end to end — write it, then re-scan clean</name>
+  <files>Cargo.toml, src/lib.rs, src/baseline.rs, src/pattern.rs, src/reporter.rs, src/main.rs, tests/baseline_test.rs</files>
+  <precondition>`sha2` version 0.10 on crates.io resolves to the RustCrypto crate (repository `https://github.com/RustCrypto/hashes`). Assert with `cargo info sha2` (or `cargo add sha2@0.10 --dry-run` plus a crates.io check) before adding it. The crate and version are fixed by D-1, so this is a provenance check, not a choice — if the repository field does not point at RustCrypto/hashes, halt and report rather than substituting another crate.</precondition>
+  <behavior>
+    Written before the implementation, in `tests/baseline_test.rs`:
+    - Test 1 (the tracer assertion): scanning `tests/fixtures/injected-skill.md` exits 1; the same
+      scan with `--write-baseline <tmp>` exits 0 and creates `<tmp>`; a third scan with
+      `--baseline <tmp>` exits 0 and its `--format json` output has an empty `matches` array, a
+      non-empty `baselined` array, and `critical_count == 0`.
+    - Test 2 (unit, in `src/baseline.rs` `#[cfg(test)]`): `fingerprint` over a fixed byte string is
+      deterministic, is prefixed `sha256:`, has 64 lowercase hex chars after the prefix, and differs
+      for a one-character-different input.
+    - Test 3 (unit): the `file` key normaliser strips exactly one leading `./` and leaves an already
+      relative path untouched.
+  </behavior>
+  <action>
+Add `sha2 = "0.10"` to `[dependencies]` in Cargo.toml (per D-1) and register `pub mod baseline;` in src/lib.rs alongside the existing modules.
+
+Create `src/baseline.rs` with rustdoc on every public item, in the house voice — state WHY, not just what, the way the `suppressed` and `low_confidence` doc comments on `ScanReport` do. Public surface:
+
+`BaselineEntry` — a serde `Serialize + Deserialize + Clone + Debug` struct carrying `file`, `pattern_id`, `digest`, `count`, and `first_seen_line`, with `#[serde(deny_unknown_fields)]` and `#[serde(default)]` on `first_seen_line` only. Explain in the doc comment that a mistyped field name must fail the parse rather than produce an entry that silently matches nothing, because an entry that matches nothing is a standing licence to re-introduce the finding it accepted.
+
+`Baseline` — `version: u32`, `generated_by: String` (`#[serde(default)]`), `entries: Vec<BaselineEntry>`. Add `pub const CURRENT_VERSION: u32 = 1;`.
+
+`fn fingerprint(matched_text: &str) -> String` — sha256 over the UTF-8 bytes, formatted `sha256:{hex}` in lowercase. Doc-comment the D-1 rationale: the payload is hashed, not stored, so the committed baseline stays inert under `DEFAULT_EXTENSIONS` (which includes `json`) and so a new payload cannot be tuned to collide with an already-accepted fingerprint.
+
+A private key type over `(file, pattern_id, digest)` suitable for a `HashMap` key, plus a private `normalise_file(&str) -> String` that strips one leading `./`. Doc-comment why: the installed pre-commit hook runs `check .` from inside a staging copy, so hook-generated paths carry the `./` prefix while `check docs/foo.md` does not, and the two must agree or the baseline is useless in the exact workflow it exists for.
+
+`Baseline::from_reports(reports: &[ScanReport]) -> Baseline` — builds entries from each report's `matches` **only** (`suppressed` and `low_confidence` are already withheld by other mechanisms and are not the user's accept-this decision), grouping by the identity triple, setting `count` to the number of occurrences in that group and `first_seen_line` to the lowest line seen. Sort entries by `(file, pattern_id, digest)` so the file is stable and diffable across runs — an adoption artifact that reorders itself produces noise in every PR.
+
+`Baseline::save(&self, path: &Path) -> anyhow::Result<()>` — pretty JSON plus a trailing newline, with `with_context` naming the path.
+
+`Baseline::load(path: &Path) -> anyhow::Result<Baseline>` — read and parse, `with_context` naming the path on both the IO and the parse error, then reject any `version` other than `CURRENT_VERSION` with an error that names both the found and the expected version. A malformed or missing file is a hard error per the locked constraints; a silently-ignored baseline is indistinguishable from a working one and would let a repository believe it is gated when it is not.
+
+`Baseline::apply(&self, reports: &mut Vec<ScanReport>) -> Vec<BaselineEntry>` — builds a remaining-budget map from the identity triple to `count`, walks each report's `matches` in order, and for each match whose triple has budget left decrements the budget and moves that match into a `baselined` vector. Rebuild each report through `ScanReport::with_baselined` (use `std::mem::take` on the report's fields) so the severity tallies are recomputed over the reduced `matches` — do not splice into an already-built report, because the tallies are what drive the exit code and CI gates. Return the entries whose budget was never touched at all, i.e. zero occurrences consumed: those are the stale ones.
+
+In `src/pattern.rs`, add `#[serde(default)] pub baselined: Vec<ScanMatch>` to `ScanReport` immediately after `low_confidence`, and extend the constructor chain with `pub fn with_baselined(file, matches, suppressed, low_confidence, baselined) -> Self`, making `with_withheld` delegate to it with an empty vec — the same shape `new` -> `with_suppressed` -> `with_withheld` already has. Add `pub fn baselined_count(&self) -> usize`. Write the doc comment in the established voice and make it say, explicitly, that these are the same `ScanMatch` type `matches` holds, filed under the reason they are not being shown, and that this is a THIRD distinct reason from the other two: `suppressed` means the scanned document disarmed the scanner, `low_confidence` means the scanner judged it documentation, and `baselined` means a human accepted it once and recorded that decision. Note the additive-field guarantee — the top-level JSON stays an array of report objects, so `spec-ci-plugin`'s parse is unaffected. Also update the `critical_count` doc comment, which currently enumerates the arrays it does not count, so it names this one too.
+
+In `src/reporter.rs`, sum `baselined_count()` across reports in `format_text` and emit a one-line note after the low-confidence note, in the same voice and with the same singular/plural handling: N finding(s) accepted by the baseline, re-run without `--baseline` to see them. Critically, add the baselined total to the `total == 0` branch's condition so a file whose only findings were baselined prints `No injection patterns reported.` and not `No injection patterns detected.` — the existing comment there already states the rule and it must not be quietly violated by the new array.
+
+In `src/main.rs`, add two options to `Commands::Check`, both `Option<PathBuf>` with `value_name = "FILE"` and doc comments explaining the adoption use case: `--baseline`, and `--write-baseline` carrying `conflicts_with = "baseline"`. Declare the mutual exclusion in clap per D-2 rather than hand-checking it. Wire them into the `Commands::Check` destructuring pattern.
+
+In the `Check` arm: immediately after `resolve_min_confidence`, before any pattern loading or stdin read, bail if `path == "-"` and `--write-baseline` was given, with a message saying stdin has no stable file identity to record. Fail before stdin is consumed so a piped producer sees the error rather than a closed pipe. After the reports vector is fully built and before the output is formatted, branch: if `--write-baseline` is set, build the baseline from the reports, save it, print the normal formatted report to stdout exactly as an unflagged run would (so `--format json` still yields a valid array and the user can see what they just accepted), print a one-line confirmation to stderr naming the entry count and the path unless `--quiet`, and `std::process::exit(exit::CLEAN)` per D-2. Otherwise, if `--baseline` is set, load it (propagating the error with `?`) and apply it to the reports before formatting.
+
+No `unwrap()` anywhere — `#![deny(clippy::unwrap_used)]` is in force in both crates.
+
+Create `tests/baseline_test.rs` with a module doc comment explaining what the file guards. Reuse the `binary()` / `Doc` / `run` helper shape from `tests/cli_surface_test.rs`, spawning through `env!("CARGO_BIN_EXE_injection-scanner")` — never a hand-built target-directory path; `tests/test_harness_contract_test.rs` fails the build otherwise. Add the three behaviours above. Use the existing `tests/fixtures/injected-skill.md` fixture rather than writing a new payload literal into this repository.
+  </action>
+  <verify>
+    <automated>cargo test --test baseline_test && cargo test --lib baseline && cargo test --test test_harness_contract_test</automated>
+  </verify>
+  <done>Scanning the injected fixture exits 1; the same scan with `--write-baseline` exits 0 and produces the file; re-scanning with `--baseline` exits 0 with an empty `matches`, a populated `baselined`, and `critical_count == 0`. `fingerprint` and `normalise_file` are unit-tested.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: The adversarial edges — count, staleness, malformed input, and the two rejections</name>
+  <files>tests/baseline_test.rs, tests/report_roundtrip_test.rs, src/baseline.rs, src/main.rs</files>
+  <behavior>
+    Each of these is written as a failing test first, then made to pass.
+
+    In `tests/baseline_test.rs`:
+    - **Occurrence beyond `count` is reported.** Write a baseline from a document containing the
+      PI001 payload once, then duplicate the payload so the document contains it twice, then scan
+      with `--baseline`. Exactly one occurrence is baselined, one remains in `matches`, and the
+      exit code is 1. Baselining N occurrences accepts N, not an unlimited number (D-1).
+    - **A stale entry is surfaced.** Scan a document with `--write-baseline`, then replace the
+      document's content with clean text, then scan with `--baseline`. Exit code is 0 and stderr
+      names the stale entry (its `pattern_id` and file) and says it can be pruned. Assert the note
+      is absent when every entry matched, so the test cannot pass vacuously.
+    - **Line moves do not invalidate an entry.** Write a baseline, then prepend several lines of
+      clean prose above the finding, then re-scan with `--baseline`: still exit 0, still baselined.
+      This is the whole point of excluding line number from identity (D-1).
+    - **A malformed baseline is a hard error.** Three cases, each asserting a non-zero exit, stderr
+      naming the offending path, and stdout carrying no scan report: (a) a file that is not JSON at
+      all, (b) valid JSON whose `entries` element is missing the `digest` field, (c) valid JSON with
+      an unrecognised `version`. A silently-ignored baseline would let a repository believe it is
+      gated when it is not.
+    - **A nonexistent `--baseline` path is a hard error**, with the same three assertions.
+    - **The two flags together are rejected.** Assert on stderr containing clap's conflict wording
+      and on a non-zero exit — do NOT assert the specific code, because clap's usage-error exit is
+      `2` and would be indistinguishable from `exit::BELOW_THRESHOLD`.
+    - **`--write-baseline` with `check -` is rejected**, non-zero exit, stderr naming stdin, and the
+      baseline file is not created.
+    - **The written baseline is inert.** Write a baseline from the injected fixture, then run the
+      scanner over the baseline file itself with `--include '**/*.json'`: zero findings, exit 0.
+      Additionally assert the baseline file's text does not contain the fixture's payload substring
+      (define that substring once as a test constant read from the fixture, do not re-type it).
+      This is D-1's core justification, tested rather than asserted in prose.
+    - **The path key survives the `./` prefix.** Write a baseline with `check .` from inside a temp
+      directory, then consume it with a scan of the same tree, and assert the findings are
+      baselined — the shape the installed pre-commit hook actually produces.
+    - **The JSON top level is still an array.** With `--format json --baseline <file>`, parse stdout
+      as `Vec<ScanReport>` (not a bare `Value`) and assert it succeeds, that the baselined record
+      carries `matched_text`, `message`, `pattern_name` and `remediation` — the full evidence, not
+      just an id — and that the severity tallies exclude it.
+
+    In `tests/report_roundtrip_test.rs`, mirroring the two guarantees already there for
+    `low_confidence`:
+    - **A report written before `baselined` existed still loads** — a v0.0.3-shaped report with
+      `suppressed` and `low_confidence` present and `baselined` absent deserializes with an empty
+      `baselined`.
+    - **A baselined finding and the same finding reported are the identical record** — the
+      `suppression_symmetry_test.rs` property, applied to the new array via `serde_json::to_value`
+      equality.
+  </behavior>
+  <action>
+Write every test above first and watch it fail for the right reason, then close whatever gap it exposes in `src/baseline.rs` or `src/main.rs`.
+
+The likely gaps, based on where the analogous features broke before:
+
+The stale-entry note has no home in `reporter.rs` — it is a run-level fact about the baseline file, not per-report data, and `format_text` has no access to it. Print it from `src/main.rs` to **stderr**, alongside the existing walk notes, gated on `!quiet` so the existing `quiet_prints_nothing_and_says_everything_through_the_exit_code` test in `tests/cli_surface_test.rs` keeps passing. Word it so it says what a stale entry costs, not just that it exists: an entry matching nothing is a standing licence to re-introduce the finding it once accepted, so it should be pruned. Define stale strictly as zero occurrences consumed — an entry that matched fewer times than its `count` is over-provisioned, not stale, and conflating the two would train users to ignore the note.
+
+The budget map must be keyed on the normalised path on **both** sides — when the baseline is written and when it is read — or the `./` test fails. Route both `from_reports` and `apply` through the same `normalise_file`.
+
+Ordering must be deterministic when the budget runs out: walk `matches` in the order the scanner produced them so which occurrence stays visible is stable across runs.
+
+Confirm the reporter's zero-total branch change from Task 1 is actually exercised — the "stale entry" test scans a clean document with a baseline in play and is the case that would print `No injection patterns detected.` if it were missed.
+
+Keep the assertion messages in the house style: each one should explain the consequence of the failure, not merely restate the expectation. `tests/suppression_symmetry_test.rs` and `tests/cli_surface_test.rs` are the models.
+  </action>
+  <verify>
+    <automated>cargo test --test baseline_test && cargo test --test report_roundtrip_test && cargo test --test cli_surface_test && cargo test</automated>
+  </verify>
+  <done>All of Task 2's listed behaviours pass; the full `cargo test` suite (25 test binaries) is green with no regression in the existing 24.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: ADR, README, and the clean-gate sweep</name>
+  <files>docs/adr/ADR-002-baseline-fingerprints.md, README.md</files>
+  <action>
+Write `docs/adr/ADR-002-baseline-fingerprints.md` following `.claude/skills/pr-artifacts/adr_template.md` and matching the numbering style of the existing `docs/adr/ADR-001-tech-stack.md`. The pr-artifacts skill requires an ADR here on two independent triggers: a new crate dependency (`sha2`) and a change to an output format contract (`ScanReport` gains a fourth array). Status Accepted, dated 2026-08-25.
+
+Context: an existing repository cannot adopt the scanner because day one is a wall of findings; a baseline is the standard answer, and the interesting question is what an entry may contain. Decision: the D-1 fingerprint — `(file, pattern_id, sha256(matched_text))` plus an occurrence `count`, with line number deliberately excluded from identity. Consequences, positive: the committed baseline is inert under a scanner whose default extension set includes `json`, so the adoption artifact cannot become a finding source; a weak digest would let an adversary who authors the scanned text tune a new payload onto an accepted fingerprint, and sha256 closes that; `count` closes "more of the same is free"; excluding the line number means editing above a finding does not force a regeneration, so the file stays a record of a decision rather than churn. Negative: a reviewer reading the baseline in a PR sees the pattern id, the path and a multiplicity but not the text, which is a real loss of review signal and was the trade consciously accepted; a stale entry is a live licence, which is why it is reported; the identity is the path string as reported, so a baseline must be generated and consumed by comparable invocations. Alternatives considered: storing the payload verbatim (rejected — the artifact becomes a finding source and leaks payloads into review), a non-cryptographic hash (rejected — crafted collisions, and the adversary authors the input), including the line number (rejected — regeneration on every commit), and unbounded acceptance per fingerprint (rejected — accepting one occurrence would accept a thousand).
+
+Update `README.md`: add a `## Adopting On An Existing Repository` section positioned immediately before `## Choosing What Fails the Build`, since the two are the same decision at different scales. Cover, in the README's existing voice: the two-command adoption flow; that `--write-baseline` exits 0 by design because it means "accept the current state"; that baselined findings are moved, never dropped, and appear under `baselined` in JSON output alongside `suppressed` and `low_confidence`; that the file stores a hash rather than the payload, and why that matters given `json` is a scanned extension; that `count` bounds acceptance so a third identical occurrence is reported; that a stale entry is reported so it can be pruned, and what a stale entry costs if it is not; and that a baseline should be generated and consumed with comparable invocations because the path is the identity. Also add a `baselined` row or note to the JSON output description around the existing `### JSON output` section so a consumer knows the fourth array exists. Do not add a new exit code to the `## Exit Codes` table — none was added; instead note in the new section that `--write-baseline` always exits `0`.
+
+Then run the code-review checklist from `.claude/skills/code-review/SKILL.md` over the diff and fix anything it flags: no `unwrap()` in production code, rustdoc on every new public item, `serde` derives on the new data structs, exhaustive pattern matching, user-facing error messages rather than raw debug output, and no stray `println!` debugging.
+  </action>
+  <verify>
+    <automated>cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && test -f docs/adr/ADR-002-baseline-fingerprints.md && grep -q 'write-baseline' README.md</automated>
+  </verify>
+  <done>ADR-002 exists and states the D-1 rationale and its trade-offs; README documents both flags and the fourth array; `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and the full test suite are all clean.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| scanned document → scanner | The adversary authors the text being fingerprinted. |
+| baseline file → scanner | A committed artifact whose entire function is to stop findings from failing a build. It is an accept-risk control, so tampering with it is the highest-value move against this feature. |
+| CLI path argument → filesystem | `--write-baseline` writes to a caller-supplied path. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-QT-01 | Tampering | `baseline.json` in a pull request | high | transfer | Transferred to code review and git history by design — a baseline is a human decision. Mitigated in support of that: entries are sorted for a stable diff, each names `file`/`pattern_id`/`count`, and stale entries are reported so unused licences surface (Task 2). |
+| T-QT-02 | Spoofing | `fingerprint` in `src/baseline.rs` | high | mitigate | sha256 over `matched_text` per D-1. The adversary authors the scanned text, so a weak digest would let a NEW payload be tuned onto an already-accepted fingerprint. Unit-tested for prefix, length and one-character sensitivity (Task 1). |
+| T-QT-03 | Elevation of Privilege | `Baseline::apply` budget map | high | mitigate | Per-fingerprint `count` budget; occurrence N+1 stays in `matches` and still fails the build. Pinned by the count-overflow test (Task 2). |
+| T-QT-04 | Information Disclosure | the committed baseline artifact | medium | mitigate | Payloads are hashed, never stored verbatim (D-1), so the baseline neither leaks payloads into review nor becomes a finding source under a default extension set that includes `json`. Pinned by the inertness test, which scans the written baseline and asserts zero findings (Task 2). |
+| T-QT-05 | Denial of Service | `Baseline::load` | high | mitigate | A malformed, missing, or unknown-version baseline is a hard error with the path named — never a silent no-op. A silently-ignored baseline lets a repository believe it is gated when it is not. Five hard-error tests (Task 2). |
+| T-QT-06 | Tampering | `Baseline::apply` tally recomputation | high | mitigate | Findings move through `ScanReport::with_baselined`, which recomputes the severity tallies over the reduced `matches`. Splicing into a built report would leave `critical_count` non-zero for a fully baselined file, or worse, leave a baselined finding counted. Pinned by the JSON tally assertion (Task 2). |
+| T-QT-07 | Repudiation | text output | medium | mitigate | `format_text` prints a baselined-count note and the zero-total branch says `reported`, not `detected` — a run that withheld findings must not read as a clean bill of health. Same rule the suppressed and low_confidence notes already follow. |
+| T-QT-08 | Tampering | `--write-baseline <PATH>` | low | accept | The path is supplied by the invoking user in their own shell, at the same trust level as any redirect they could write themselves. No privilege boundary is crossed. |
+| T-QT-SC | Tampering | `cargo add sha2` | high | mitigate | The crate and version are fixed by locked decision D-1, not chosen by the executor. Task 1 carries a `<precondition>` asserting `sha2` 0.10 resolves to the RustCrypto crate (`github.com/RustCrypto/hashes`) before it is added, with a halt on mismatch. Note: no RESEARCH.md package-legitimacy table exists for this quick task; the precondition is the substitute gate and its outcome must be recorded in the SUMMARY. |
+</threat_model>
+
+<verification>
+- `cargo fmt --check` clean.
+- `cargo clippy --all-targets -- -D warnings` clean, with `#![deny(clippy::unwrap_used)]` still present in both crate roots (`tests/test_harness_contract_test.rs` enforces this).
+- `cargo test` green across all 25 test binaries — the 24 existing plus `baseline_test`.
+- `tests/test_harness_contract_test.rs` passes, confirming `tests/baseline_test.rs` spawns through `env!("CARGO_BIN_EXE_injection-scanner")`.
+- Manual end-to-end sanity on this repository: `cargo run -- check . --write-baseline /tmp/b.json` exits 0, then `cargo run -- check . --baseline /tmp/b.json` exits 0, then `cargo run -- check /tmp/b.json --include '**/*.json'` reports nothing.
+</verification>
+
+<success_criteria>
+- Every truth in `must_haves.truths` is pinned by a named test.
+- D-1 is implemented exactly: sha256 digest, occurrence `count`, line number excluded from identity, `sha2 = "0.10"`.
+- D-2 is implemented exactly: `--write-baseline` exits `exit::CLEAN`; `--baseline` populates a new `baselined` array; the two flags are mutually exclusive via clap `conflicts_with`; nothing is dropped; text output carries a one-line count in the established voice; stale entries are reported.
+- `spec-ci-plugin`'s contract is intact: `--format json` still parses as `Vec<ScanReport>`, and a v0.0.3-era report still deserializes.
+- ADR-002 and the README section exist; the code-review checklist has been run over the diff.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260825-tc7-cli-08-implement-baseline-file-for-incre/260825-tc7-SUMMARY.md` when done.
+Record in it: the `sha2` provenance check outcome (T-QT-SC), the final stale-entry note wording, and
+whether the `./` path normalisation held for the pre-commit-hook invocation shape.
+</output>

--- a/.planning/quick/260825-tc7-cli-08-implement-baseline-file-for-incre/260825-tc7-SUMMARY.md
+++ b/.planning/quick/260825-tc7-cli-08-implement-baseline-file-for-incre/260825-tc7-SUMMARY.md
@@ -1,0 +1,330 @@
+---
+phase: quick-260825-tc7
+plan: 01
+subsystem: cli
+tags: [rust, cli, baseline, sha2, adoption, clap]
+
+requires:
+  - phase: Phase 4 — Integration (v0.1.0)
+    provides: "--fail-on, --quiet, exit code 2, rules, explain (PR #76); the suppressed/low_confidence withheld-findings pattern ScanReport already established"
+provides:
+  - "src/baseline.rs: BaselineEntry/Baseline, fingerprint (sha256), normalise_file, from_reports/save/load/apply"
+  - "ScanReport.baselined: Vec<ScanMatch> — a fourth withheld-findings array, plus ScanReport::with_baselined"
+  - "--baseline <FILE> / --write-baseline <FILE> on `check`, mutually exclusive via clap conflicts_with"
+  - "docs/adr/ADR-002-baseline-fingerprints.md and a README 'Adopting On An Existing Repository' section"
+affects: [issue-25, CLI-08, spec-ci-plugin-consumer-contract]
+
+actuals:
+  tokens: 14000
+  tasks: 3
+  commits: 3
+
+tech-stack:
+  added: ["sha2 = \"0.10\" (RustCrypto, github.com/RustCrypto/hashes)"]
+  patterns:
+    - "Baseline module owns identification/mutation logic only; main.rs owns CLI plumbing (flag parsing, stdin rejection, exit codes) — same separation as scanner.rs/main.rs"
+    - "Fourth withheld-findings array follows the suppressed/low_confidence precedent exactly: additive #[serde(default)] field, recomputed severity tallies via a with_* constructor, never spliced into an already-built report"
+
+key-files:
+  created:
+    - src/baseline.rs
+    - tests/baseline_test.rs
+    - docs/adr/ADR-002-baseline-fingerprints.md
+  modified:
+    - Cargo.toml
+    - Cargo.lock
+    - src/lib.rs
+    - src/pattern.rs
+    - src/reporter.rs
+    - src/main.rs
+    - tests/report_roundtrip_test.rs
+    - README.md
+
+key-decisions:
+  - "D-1 implemented exactly: sha256 digest over matched_text (sha2 0.10, provenance-verified RustCrypto/hashes), occurrence count budget, line number excluded from identity."
+  - "D-2 implemented exactly: --write-baseline always exits exit::CLEAN; --baseline populates ScanReport.baselined; the two flags are mutually exclusive via clap conflicts_with (not hand-checked); nothing is dropped; text output carries a one-line count; stale entries are reported on stderr."
+  - "Stale-entry note lives in main.rs (stderr, gated on !quiet), not reporter.rs — it is a run-level fact about the baseline file, not per-report data, matching the plan's own diagnosis of where the gap would be."
+  - "Task 1 (the tracer) was implemented as a complete, production-quality slice — budget map, both-sides normalise_file keying, deterministic match ordering, and the stale note were all built in Task 1 rather than deferred. Task 2's adversarial tests therefore passed on first run against Task 1's code, with zero additional source changes needed."
+
+requirements-completed: [CLI-08]
+
+coverage:
+  - id: D1
+    description: "check <path> --write-baseline <FILE> scans, writes FILE, and exits 0 even with CRITICAL findings"
+    requirement: CLI-08
+    verification:
+      - kind: integration
+        ref: "tests/baseline_test.rs#the_two_command_adoption_flow_works_end_to_end"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "check <path> --baseline <FILE> moves fingerprint-matched findings into baselined, empties matches, zeroes severity tallies, and exits 0"
+    requirement: CLI-08
+    verification:
+      - kind: integration
+        ref: "tests/baseline_test.rs#the_two_command_adoption_flow_works_end_to_end"
+        status: pass
+      - kind: integration
+        ref: "tests/baseline_test.rs#baselined_findings_carry_full_evidence_and_the_top_level_stays_an_array"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "Occurrence beyond an entry's count is still reported and still fails the build"
+    requirement: CLI-08
+    verification:
+      - kind: integration
+        ref: "tests/baseline_test.rs#an_occurrence_beyond_count_is_still_reported"
+        status: pass
+    human_judgment: false
+  - id: D4
+    description: "A baseline entry that matched nothing this run is surfaced as a stale note, absent when every entry matched"
+    requirement: CLI-08
+    verification:
+      - kind: integration
+        ref: "tests/baseline_test.rs#a_stale_entry_is_surfaced_and_only_when_stale"
+        status: pass
+    human_judgment: false
+  - id: D5
+    description: "Line number excluded from identity — editing lines above a finding does not invalidate its baseline entry"
+    requirement: CLI-08
+    verification:
+      - kind: integration
+        ref: "tests/baseline_test.rs#editing_lines_above_a_finding_does_not_invalidate_its_baseline_entry"
+        status: pass
+    human_judgment: false
+  - id: D6
+    description: "Malformed, missing, or unknown-version baseline is a hard error, never a silent no-op"
+    requirement: CLI-08
+    verification:
+      - kind: integration
+        ref: "tests/baseline_test.rs#a_baseline_that_is_not_json_is_a_hard_error"
+        status: pass
+      - kind: integration
+        ref: "tests/baseline_test.rs#a_baseline_entry_missing_a_required_field_is_a_hard_error"
+        status: pass
+      - kind: integration
+        ref: "tests/baseline_test.rs#a_baseline_with_an_unrecognised_version_is_a_hard_error"
+        status: pass
+      - kind: integration
+        ref: "tests/baseline_test.rs#a_nonexistent_baseline_path_is_a_hard_error"
+        status: pass
+    human_judgment: false
+  - id: D7
+    description: "--baseline and --write-baseline are mutually exclusive (clap); --write-baseline against check - is rejected before stdin is read"
+    requirement: CLI-08
+    verification:
+      - kind: integration
+        ref: "tests/baseline_test.rs#baseline_and_write_baseline_together_are_rejected"
+        status: pass
+      - kind: integration
+        ref: "tests/baseline_test.rs#write_baseline_with_stdin_is_rejected"
+        status: pass
+    human_judgment: false
+  - id: D8
+    description: "The written baseline is inert — hashed payload only, scanning it finds nothing"
+    requirement: CLI-08
+    verification:
+      - kind: integration
+        ref: "tests/baseline_test.rs#the_written_baseline_is_inert"
+        status: pass
+    human_judgment: false
+  - id: D9
+    description: "The ./ path normalisation holds for the check . invocation shape the pre-commit hook uses"
+    requirement: CLI-08
+    verification:
+      - kind: integration
+        ref: "tests/baseline_test.rs#the_path_key_survives_the_leading_dot_slash_prefix_from_check_dot"
+        status: pass
+    human_judgment: false
+  - id: D10
+    description: "ScanReport.baselined is additive — a pre-baselined report still deserializes, and a baselined finding is identical in shape to the same finding reported"
+    requirement: CLI-08
+    verification:
+      - kind: integration
+        ref: "tests/report_roundtrip_test.rs#a_report_written_before_baselined_existed_still_loads"
+        status: pass
+      - kind: integration
+        ref: "tests/report_roundtrip_test.rs#a_baselined_finding_and_the_same_finding_reported_are_the_identical_record"
+        status: pass
+    human_judgment: false
+  - id: D11
+    description: "ADR-002 and the README 'Adopting On An Existing Repository' section document the feature"
+    requirement: CLI-08
+    verification:
+      - kind: other
+        ref: "docs/adr/ADR-002-baseline-fingerprints.md exists; grep 'write-baseline' README.md"
+        status: pass
+    human_judgment: false
+
+duration: ~55min
+completed: 2026-08-25
+status: complete
+---
+
+# Quick Task 260825-tc7: CLI-08 `--baseline` Summary
+
+**`--baseline <FILE>` / `--write-baseline <FILE>` for incremental adoption, backed by sha256 fingerprints (RustCrypto/hashes-verified `sha2 0.10`) and an occurrence-count budget, closing the last open item on issue #25.**
+
+## Performance
+
+- **Duration:** ~55 min
+- **Tasks:** 3/3 completed
+- **Files modified:** 8 (2 new source files, 1 new ADR, 1 new test file, 4 modified)
+- **Commits:** 3 (feat, test, docs)
+
+## Accomplishments
+
+- Implemented the full baseline lifecycle in a new `src/baseline.rs`: `BaselineEntry`/`Baseline`
+  types, `fingerprint` (sha256 over `matched_text`, prefixed `sha256:`), `normalise_file` (strips
+  one leading `./`), and `from_reports`/`save`/`load`/`apply`.
+- Extended `ScanReport` with a fourth withheld-findings array, `baselined`, via a new
+  `ScanReport::with_baselined` constructor that recomputes severity tallies over the reduced
+  `matches` — following the exact precedent `suppressed`/`low_confidence` set.
+- Wired `--baseline <FILE>` and `--write-baseline <FILE>` onto `check`, mutually exclusive via
+  clap `conflicts_with`, with `--write-baseline` rejected against `check -` before stdin is read,
+  and `--write-baseline` always exiting `exit::CLEAN` per D-2.
+- `format_text` gained a baselined-count note, and the zero-total branch now also treats a
+  fully-baselined file as "reported", not "detected".
+- Wrote 13 new integration tests in `tests/baseline_test.rs` (tracer + adversarial edges) and 2
+  new tests in `tests/report_roundtrip_test.rs` (backward-compat deserialization, shape symmetry).
+- Wrote `docs/adr/ADR-002-baseline-fingerprints.md` and a new README "Adopting On An Existing
+  Repository" section.
+
+## sha2 Provenance Check (T-QT-SC)
+
+**Outcome: PASS.** Before adding the dependency, ran `cargo info sha2@0.10` and confirmed
+`repository: https://github.com/RustCrypto/hashes`, matching D-1's fixed choice exactly. Resolved
+version is `0.10.9` (latest patch under `0.10`). Confirmed again after `cargo add`/`cargo build`
+via the resulting `Cargo.lock` entry. No substitution was needed and none was considered.
+
+## Final Stale-Entry Note Wording
+
+Printed to **stderr**, one line per stale entry, gated on `!quiet`:
+
+```
+note: baseline entry {pattern_id} in {file} matched nothing this run and can be pruned — an entry
+matching nothing is a standing licence to re-introduce the finding it once accepted.
+```
+
+Verified absent in the control case (an entry that still matched) and present only when an entry
+consumed zero occurrences of its budget — `tests/baseline_test.rs::a_stale_entry_is_surfaced_and_only_when_stale`
+asserts both directions so the test cannot pass vacuously.
+
+## `./` Path Normalisation For The Pre-Commit-Hook Invocation Shape
+
+**Held.** `tests/baseline_test.rs::the_path_key_survives_the_leading_dot_slash_prefix_from_check_dot`
+runs `check . --write-baseline baseline.json` then `check . --baseline baseline.json --format json`
+from inside a temp directory — the exact shape `hook_script()` in `src/main.rs` uses — and asserts
+the `skill.md` finding is baselined on the second run. `normalise_file` is applied on both sides
+(`Baseline::from_reports` and `Baseline::apply`), which is what makes this hold.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: One accepted finding, end to end — write it, then re-scan clean** - `f73e685` (feat)
+2. **Task 2: The adversarial edges — count, staleness, malformed input, and the two rejections** - `4349765` (test)
+3. **Task 3: ADR, README, and the clean-gate sweep** - `86bfccd` (docs)
+
+**Plan metadata:** commit deferred — the orchestrator handles the `.planning/` docs commit for
+this quick task; this SUMMARY.md was written to disk (worktree copy — the write sandbox refused
+the primary-checkout path given in the plan's `<output>` section; see Deviations) but is not
+committed by this execution.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+None — plan executed exactly as written, task order and scope unchanged.
+
+### Process deviations (not defects, documented per instructions)
+
+**1. [Environment constraint] SUMMARY.md was written to the worktree's copy of the path, not the
+primary-checkout path the plan's `<output>` section specified.** The plan asked for the SUMMARY to
+be written to
+`/Users/jirihermann/Documents/workspace-1-ideas/unity-in-flow-ai/03-injection-scanner/.planning/quick/260825-tc7-cli-08-implement-baseline-file-for-incre/260825-tc7-SUMMARY.md`
+in the primary checkout. The `Write` tool refused that path outright with: "This agent is isolated
+in the worktree ...; Edit the worktree copy of this file instead of the shared-checkout path." This
+is a hard sandbox restriction on this execution, not a discretionary choice — every attempt to
+touch the primary checkout (including a read-only `git status`) was blocked the same way. The file
+was written instead to
+`.claude/worktrees/agent-a69608121ef39d47c/.planning/quick/260825-tc7-cli-08-implement-baseline-file-for-incre/260825-tc7-SUMMARY.md`
+(the equivalent path inside the worktree, which did not previously contain this quick-task
+subdirectory since the worktree was forked before it existed in the primary checkout). **The
+orchestrator will need to copy or merge this file to the primary-checkout path itself** — this
+executor has no tool capability to do so from inside the worktree sandbox.
+
+**2. Task 2's tests passed on first run, without additional source changes.** The plan describes
+Task 2 as "each of these is written as a failing test first, then made to pass," anticipating
+specific gaps (the stale-entry note's home, both-sides path-key normalisation, deterministic
+budget-exhaustion ordering, the reporter zero-total branch). Task 1 was executed as a genuinely
+complete, production-quality tracer slice — informed by having read the full plan (including
+Task 2's adversarial list) before writing Task 1's implementation — and already closed all of
+those anticipated gaps: the stale-entry note was placed in `main.rs` from the start, `normalise_file`
+was applied in both `from_reports` and `apply`, match iteration order was preserved via
+`std::mem::take`, and the reporter's zero-total branch included `total_baselined` from the first
+edit. All 13 of Task 2's tests were written, run, and passed immediately — confirmed by re-running
+them individually and as a suite with no intervening implementation edits. This is a deviation
+from the letter of "write a failing test, watch it fail, then close the gap it exposes" (RED did
+not occur test-by-test for Task 2), but not from the plan's actual intent: every behaviour in
+`must_haves.truths` is pinned by a named, currently-passing test, and Task 1's own RED/GREEN
+cycle (unit tests for `fingerprint`/`normalise_file`, and the end-to-end tracer test) was performed
+strictly, with both confirmed failing for the right reason before implementation.
+
+## Authentication Gates
+
+None encountered.
+
+## Known Stubs
+
+None. No hardcoded empty values, placeholder text, or unwired data sources were introduced.
+
+## Threat Flags
+
+None beyond what the plan's own `<threat_model>` already covers — no new network endpoints, auth
+paths, or trust-boundary schema changes were introduced outside the `baseline.json`
+read/write/apply surface the threat register already accounts for (T-QT-01 through T-QT-SC).
+
+## Final Gate
+
+```
+cargo fmt --check               PASS (clean on final check; `cargo fmt` was applied twice during
+                                  Task 1/Task 2 to fix formatting introduced by manual multi-line
+                                  edits before each task's commit)
+cargo clippy --all-targets -- -D warnings   PASS (zero warnings)
+cargo test                      PASS — 196 tests passed, 0 failed, across 25 test result blocks
+                                  (24 pre-existing test binaries + unit tests, plus the new
+                                  tests/baseline_test.rs; the 24-binary baseline from STATE.md
+                                  becomes 25 with this addition)
+test -f docs/adr/ADR-002-baseline-fingerprints.md   PASS
+grep -q 'write-baseline' README.md                  PASS
+```
+
+Manual end-to-end sanity (per the plan's `<verification>` section), run against this repository
+from the worktree root:
+
+```
+$ injection-scanner check . --write-baseline <tmp>/b.json
+  ... 54 finding(s): 21 critical, 17 high, 16 medium, 0 low
+  ... 22 findings suppressed ... 93 findings withheld as documentation ...
+  note: wrote 54 baseline entries to <tmp>/b.json
+exit 0
+
+$ injection-scanner check . --baseline <tmp>/b.json
+exit 0
+
+$ injection-scanner check <tmp>/b.json --include '**/*.json'
+No injection patterns detected.
+exit 0
+```
+
+All three steps matched the plan's expected behavior exactly.
+
+## Self-Check: PASSED
+
+- FOUND: src/baseline.rs
+- FOUND: tests/baseline_test.rs
+- FOUND: docs/adr/ADR-002-baseline-fingerprints.md
+- FOUND: commit f73e685 (feat: --baseline / --write-baseline for incremental adoption)
+- FOUND: commit 4349765 (test: adversarial baseline edges)
+- FOUND: commit 86bfccd (docs: ADR-002 and README for --baseline / --write-baseline)

--- a/.planning/quick/260825-uor-cli-04-sarif-2-1-0-output-format-issue-5/260825-uor-CONTEXT.md
+++ b/.planning/quick/260825-uor-cli-04-sarif-2-1-0-output-format-issue-5/260825-uor-CONTEXT.md
@@ -1,0 +1,74 @@
+# Context — CLI-04, SARIF 2.1.0 output
+
+**Locked by the user 2026-08-25. Plan against these; do not re-open them.**
+
+Requirement **CLI-04** (`.planning/REQUIREMENTS.md`, Phase 4): "SARIF 2.1.0 output that validates
+against the schema and uploads to GitHub code scanning". GitHub issue **#5**.
+
+This is the last unmet *original* v0.0.1 promise. `--format sarif` returning human-readable text
+with a findings exit code was one of the audit findings that opened this milestone — the variant
+was then deliberately withheld from the `OutputFormat` enum until a writer existed. See the doc
+comment on `OutputFormat` in `src/main.rs`; adding the variant without the writer is precisely
+what that comment forbids.
+
+## D-1 — Only `matches` become SARIF results
+
+`suppressed`, `low_confidence` and `baselined` are **not** emitted as results. SARIF carries
+exactly what the exit code acts on: one result per reported finding.
+
+Rationale: a code-scanning alert means "act on this". The three withheld arrays each mean the
+opposite, for three different reasons. They stay visible in `--format json`, which is where a
+consumer that wants the full picture already looks.
+
+SARIF 2.1.0's `suppressions` property was considered and rejected for this milestone — it would
+put baselined findings in front of reviewers as dismissed alerts, which is noise in the exact
+workflow `--baseline` exists to quiet.
+
+## D-2 — Branch and merge order
+
+Stacked on `feat/cli-08-baseline` (PR #79), because both touch `OutputFormat` in `src/main.rs`
+and `src/reporter.rs`.
+
+**Hazard, recorded from experience in this repo:** it rebase-merges with zero merge commits, and
+merging a parent PR with `--delete-branch` **auto-closes the stacked child**; GitHub then refuses
+both `gh pr reopen` and retargeting. The child must be retargeted to `main` *before* #79's branch
+is deleted. This is an orchestrator concern, not an implementation one — noted here so it is not
+lost.
+
+## Design guidance (not locked — plan it, but start here)
+
+**Severity mapping.** SARIF `level` is one of `error` / `warning` / `note` / `none`, which does
+not match this tool's four-level severity. Proposed: CRITICAL and HIGH → `error`, MEDIUM →
+`warning`, LOW → `note`. The full severity must survive the lossy mapping — carry it in
+`properties` and/or `rank` so a consumer can recover it. Do not silently flatten.
+
+**Reuse the CLI-08 fingerprint for `partialFingerprints`.** SARIF uses these to keep an alert
+identified across runs, so GitHub does not close and reopen the same alert when a line moves.
+`baseline::fingerprint` already computes exactly the right thing — sha256 over `matched_text`,
+deliberately independent of line number — and it is already public. Reusing it means the baseline
+and the code-scanning alert agree on what "the same finding" means, which is a real property, not
+a convenience.
+
+**Rules.** Emit `tool.driver.rules` from the loaded pattern set: `id`, `name`,
+`shortDescription`, `fullDescription`, `help` carrying the remediation, and `properties` with the
+category and the native severity. Each result references its rule by `ruleId`. `explain <PI0XX>`
+already assembles this material — reuse rather than re-derive.
+
+**Validation without a network.** Tests must not fetch the schema at runtime. Prefer structural
+assertions plus, if a schema check is wanted, a vendored copy — decide and justify. The real
+end-to-end proof is a CI job uploading to code scanning, which is where "validates against the
+2.1.0 schema" is actually settled.
+
+## Non-negotiable constraints
+
+- `--format json` output must not change. Top level stays an array of report objects —
+  `spec-ci-plugin` does `JSON.parse(output) as Array<...>`.
+- SARIF is a **new** `OutputFormat` variant; the `match` in `main.rs` is exhaustive by
+  construction, which is the point of the enum.
+- `#![deny(clippy::unwrap_used)]` in both crates. No `unwrap()`.
+- Integration tests MUST spawn via `env!("CARGO_BIN_EXE_injection-scanner")` —
+  `tests/test_harness_contract_test.rs` fails the build on a hand-built target path.
+- Do not write verbatim injection payloads into new repository files; reuse `tests/fixtures/`.
+  This repo scans itself.
+- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean; never commit failing
+  tests.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +209,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +284,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +343,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -381,6 +429,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "thiserror",
  "unicode-normalization",
  "unicode-security",
@@ -652,6 +701,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +786,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +833,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = "2"
 ignore = "0.4.33"
 unicode-normalization = "0.1.25"
 unicode-security = "0.1.2"
+sha2 = "0.10"
 
 [dev-dependencies]
 # Benchmarks only (`benches/scan.rs`). The CI-enforced perf guard is a plain

--- a/README.md
+++ b/README.md
@@ -465,9 +465,25 @@ for the full rationale.
 A baseline entry that matches nothing in a given run is reported on stderr as
 stale: it is a live licence to re-introduce the finding it once accepted, and should
 be pruned. Generate and consume a baseline with comparable invocations — the path is
-part of an entry's identity, so a baseline written by `check .` (exactly how the
-installed pre-commit hook invokes the scanner) matches a later `check .`, but not
-necessarily a differently-rooted invocation.
+part of an entry's identity, so a baseline written by `check .` matches a later
+`check .`, but not necessarily a differently-rooted invocation.
+
+### With the pre-commit hook
+
+The hook does **not** pick a baseline up from the working directory; tell it which
+one to honour at install time:
+
+```bash
+injection-scanner install-hook --baseline .injection-scanner-baseline.json
+```
+
+Without this, a repository that just accepted its findings still cannot commit — the
+hook re-reports every one of them. The path is resolved to an absolute one when the
+hook is written, because the hook scans from inside a temporary staging copy where a
+relative path would not exist, and a baseline that cannot be found is refused at
+install time rather than on someone's next commit. New findings still block, and so
+does the *same* payload in a *new* file: the path is part of an entry's identity, so
+accepting yesterday's debt never becomes a licence to add more of it.
 
 `--baseline` and `--write-baseline` are mutually exclusive, and `--write-baseline`
 is rejected against `check -`: stdin has no stable file identity to record a

--- a/README.md
+++ b/README.md
@@ -228,6 +228,14 @@ tests/fixtures/injected-skill.md
 ]
 ```
 
+Three more arrays can appear alongside `matches`, one per reason a finding can be
+withheld rather than reported: `suppressed` (an in-file directive disarmed it),
+`low_confidence` (markdown context scored it as documentation), and `baselined` (a
+`--baseline` file accepted it in a prior run — see
+[Adopting On An Existing Repository](#adopting-on-an-existing-repository)). All
+three are additive with `#[serde(default)]`, so older reports still deserialize,
+and none of them affect `critical_count` and friends.
+
 ## Documentation Is Not an Attack
 
 A security guide that quotes `ignore all previous instructions` is documenting an
@@ -422,6 +430,48 @@ repos:
     hooks:
       - id: injection-scanner
 ```
+
+## Adopting On An Existing Repository
+
+An existing repository cannot adopt this scanner if day one is a wall of findings.
+`--baseline` accepts the current state once, so only *new* findings fail the build
+from then on:
+
+```bash
+injection-scanner check . --write-baseline .injection-scanner-baseline.json
+injection-scanner check . --baseline .injection-scanner-baseline.json
+```
+
+`--write-baseline` always exits `0` — by design. Writing the baseline **is** the
+accept decision, so it cannot also be the thing that fails the build, even when the
+scan found CRITICAL findings.
+
+Accepted findings are moved, never dropped. `--format json` carries them in a
+fourth array, `baselined`, alongside `matches`, `suppressed` and `low_confidence` —
+same shape, same full evidence, filed under a third distinct reason a finding can be
+withheld: a human accepted it once and recorded that decision. Severity tallies
+(`critical_count` and friends) never count a baselined finding.
+
+The file stores a **hash** of the matched text, never the payload itself — because
+`json` is scanned by default (see `DEFAULT_EXTENSIONS` above), and a committed
+baseline full of verbatim payloads would itself become a finding source on the next
+scan. Each entry also carries a `count`, so accepting one occurrence of a pattern
+accepts exactly one: a third identical occurrence is still reported. Line number is
+deliberately **not** part of an entry's identity — editing anything above a finding
+does not invalidate its baseline entry, so the file stays a record of a decision
+rather than churn on every commit. See `docs/adr/ADR-002-baseline-fingerprints.md`
+for the full rationale.
+
+A baseline entry that matches nothing in a given run is reported on stderr as
+stale: it is a live licence to re-introduce the finding it once accepted, and should
+be pruned. Generate and consume a baseline with comparable invocations — the path is
+part of an entry's identity, so a baseline written by `check .` (exactly how the
+installed pre-commit hook invokes the scanner) matches a later `check .`, but not
+necessarily a differently-rooted invocation.
+
+`--baseline` and `--write-baseline` are mutually exclusive, and `--write-baseline`
+is rejected against `check -`: stdin has no stable file identity to record a
+baseline against.
 
 ## Choosing What Fails the Build
 

--- a/docs/adr/ADR-002-baseline-fingerprints.md
+++ b/docs/adr/ADR-002-baseline-fingerprints.md
@@ -1,0 +1,92 @@
+# ADR-002: Baseline Fingerprints
+
+Date: 2026-08-25
+Status: Accepted
+
+## Context
+
+An existing repository cannot adopt this scanner if day one is a wall of findings —
+issue #25 calls `--baseline` "the single highest-value adoption feature here". A
+baseline that lets a repository accept its current findings once and gate only new
+ones is the standard answer. The interesting question is what an accepted entry may
+contain.
+
+The scanner's own `DEFAULT_EXTENSIONS` list (`src/walk.rs`) includes `json`, and a
+baseline is itself a committed JSON file living in the repository it gates. Any
+design that stores the payload verbatim turns the adoption artifact into a finding
+source on the very next scan — the tool that is supposed to make the repository
+adoptable would fail its own gate.
+
+This ADR is required on two independent `pr-artifacts` triggers: a new crate
+dependency (`sha2`) and a change to an output format contract (`ScanReport` gains a
+fourth array, `baselined`).
+
+## Decision
+
+An accepted finding is identified by the triple `(file, pattern_id, digest)`, where
+`digest` is `sha256:<hex>` computed over the bytes of `matched_text`, plus an
+occurrence `count` recording how many identical fingerprints were accepted. Line
+number (`first_seen_line`) is carried for information only and is deliberately
+excluded from identity.
+
+`--write-baseline <FILE>` scans, writes this file, and exits `0` — writing the
+baseline IS the accept decision, so it cannot also be a failure. `--baseline <FILE>`
+moves every finding whose fingerprint is recorded, up to its `count`, out of
+`matches` and into a new `baselined: Vec<ScanMatch>` array on `ScanReport`,
+recomputed through `ScanReport::with_baselined` so the severity tallies never count
+an accepted finding.
+
+New dependency: `sha2 = "0.10"` (RustCrypto, `github.com/RustCrypto/hashes`;
+provenance verified against the locked decision before being added, per the
+`<precondition>` on Task 1 of the executing plan — see threat T-QT-SC).
+
+## Consequences
+
+### Positive
+
+- The committed baseline is inert under a scanner whose default extension set
+  includes `json`: hashing means the adoption artifact can never become a finding
+  source under its own gate.
+- A weak or non-cryptographic digest would let an adversary who authors the scanned
+  text — the same adversary this whole tool defends against — tune a *new* payload
+  to collide with an already-accepted fingerprint (T-QT-02). sha256 closes that.
+- `count` closes "more of the same is free": baselining two occurrences accepts two,
+  not an unlimited number. A third identical occurrence is still reported (T-QT-03).
+- Excluding the line number from identity means editing anything above a finding
+  does not force the baseline to be regenerated — the file stays a record of a
+  decision made once, rather than churn on every commit.
+- Nothing is dropped: `baselined` follows the same rationale as `suppressed` and
+  `low_confidence` — a finding withheld is filed under the reason it was withheld,
+  never discarded, and additive with `#[serde(default)]` so `spec-ci-plugin`'s
+  `JSON.parse(output) as Array<...>` contract is unaffected.
+
+### Negative / Trade-offs
+
+- A reviewer reading the baseline in a pull request sees `PI001 in docs/foo.md ×2`,
+  not the matched text. That is a real loss of review signal, and the trade the
+  user consciously chose (D-1) rather than the alternative below.
+- A stale entry — one that matches nothing this run — is a live licence to
+  re-introduce the finding it once accepted. It cannot be prevented structurally,
+  only surfaced: a stale-entry note on stderr names the pattern and file so it can
+  be pruned (T-QT-01).
+- Identity is the path string exactly as the scanner reports it (minus one leading
+  `./`), so a baseline must be generated and consumed by comparable invocations —
+  `check .` and `check docs/foo.md` key differently unless the normalisation is
+  applied on both sides, which is why it is applied on both `from_reports` and
+  `apply` rather than once.
+
+## Alternatives Considered
+
+- **Store the payload verbatim.** Rejected — the artifact becomes a finding source
+  under the scanner's own default extension set, and leaks payload text into every
+  PR review that touches the baseline.
+- **A non-cryptographic hash (e.g. FNV, CRC32).** Rejected — the adversary authors
+  the scanned input, and a fast, non-cryptographic hash gives them a tractable
+  target to tune a new payload onto an already-accepted fingerprint.
+- **Include the line number in identity.** Rejected — regenerating the baseline on
+  every commit that shifts lines above a finding would make the file pure churn,
+  defeating its purpose as a durable record of a decision.
+- **Unbounded acceptance per fingerprint (no `count`).** Rejected — accepting one
+  occurrence of a pattern would silently accept an unlimited number of future
+  occurrences of the identical text, which is a much larger grant than "we saw this
+  once and decided it was fine."

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -194,9 +194,16 @@ impl Baseline {
     /// them, so which occurrence stays visible when the budget runs out is
     /// stable across runs.
     ///
-    /// Returns the entries whose budget was never touched at all — zero
-    /// occurrences consumed — which is the definition of stale used to
-    /// surface the prunable-entry note.
+    /// Returns the stale entries: those naming a file this run actually
+    /// scanned, which consumed zero occurrences of it.
+    ///
+    /// Scoping to scanned files is load-bearing, not a refinement. The
+    /// pre-commit hook scans only STAGED files, so on a commit touching one
+    /// unrelated file every other entry consumes nothing — and reporting all
+    /// of them as prunable, on every commit, is how the one note that matters
+    /// becomes wallpaper. An entry for a file outside the run's scope says
+    /// nothing about whether its finding is gone, so this says nothing about
+    /// it either.
     pub fn apply(&self, reports: &mut [ScanReport]) -> Vec<BaselineEntry> {
         let mut budget: HashMap<Identity, usize> = HashMap::new();
         for entry in &self.entries {
@@ -213,6 +220,12 @@ impl Baseline {
                 .or_insert(0) += entry.count;
         }
         let mut touched: HashSet<Identity> = HashSet::new();
+        // Which files this run actually opened. Without it, "consumed nothing"
+        // is indistinguishable from "was never looked at".
+        let scanned: HashSet<String> = reports
+            .iter()
+            .map(|report| normalise_file(&report.file))
+            .collect();
 
         for report in reports.iter_mut() {
             let mut kept = Vec::new();
@@ -247,8 +260,12 @@ impl Baseline {
         self.entries
             .iter()
             .filter(|entry| {
+                let file = normalise_file(&entry.file);
+                if !scanned.contains(&file) {
+                    return false;
+                }
                 let identity = Identity {
-                    file: normalise_file(&entry.file),
+                    file,
                     pattern_id: entry.pattern_id.clone(),
                     digest: entry.digest.clone(),
                 };

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,0 +1,307 @@
+//! Baseline files for incremental adoption on an existing repository (issue
+//! #25, CLI-08).
+//!
+//! An existing repository cannot adopt this scanner if day one is a wall of
+//! findings. `--write-baseline` records the current findings as accepted;
+//! `--baseline` then withholds exactly those findings from later scans,
+//! leaving new ones to still fail the build. This module is deliberately
+//! narrow: it identifies and moves findings; the CLI plumbing (flag parsing,
+//! stdin rejection, process exit codes) lives in `main.rs`.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::pattern::ScanReport;
+
+/// The only baseline schema version this build understands.
+///
+/// A file written by a future version with a higher number must be rejected
+/// rather than silently misread — see `Baseline::load`.
+pub const CURRENT_VERSION: u32 = 1;
+
+/// One accepted finding, identified by `(file, pattern_id, digest)`.
+///
+/// `#[serde(deny_unknown_fields)]`: a mistyped field name must fail the parse
+/// rather than produce an entry that silently matches nothing, because an
+/// entry that matches nothing is a standing licence to re-introduce the
+/// finding it accepted. `first_seen_line` is `#[serde(default)]` and is
+/// informational only — it is deliberately NOT part of identity, so editing
+/// anything above a finding does not force the baseline to be regenerated.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BaselineEntry {
+    pub file: String,
+    pub pattern_id: String,
+    pub digest: String,
+    pub count: usize,
+    #[serde(default)]
+    pub first_seen_line: usize,
+}
+
+/// A committed record of accepted findings.
+///
+/// The top-level shape here is a JSON *object*, not an array — this is a new
+/// artifact and is unrelated to the `--format json` report stream, whose
+/// array-at-top-level contract `spec-ci-plugin` depends on is untouched.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Baseline {
+    pub version: u32,
+    #[serde(default)]
+    pub generated_by: String,
+    pub entries: Vec<BaselineEntry>,
+}
+
+/// Identity of one accepted finding: `(file, pattern_id, digest)`.
+///
+/// Line number is deliberately excluded (D-1): editing anything above a
+/// finding must not invalidate its baseline entry, or the file stops being a
+/// record of a decision and becomes churn on every commit.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct Identity {
+    file: String,
+    pattern_id: String,
+    digest: String,
+}
+
+/// sha256 over the UTF-8 bytes of `matched_text`, formatted `sha256:<hex>`.
+///
+/// The payload is hashed, not stored, so a committed baseline stays inert
+/// under `DEFAULT_EXTENSIONS` (which includes `json`) — the adoption artifact
+/// must never itself become a finding source. Hashing also removes the
+/// crafted-collision surface: the adversary authors the scanned text, so a
+/// weak digest would let a *new* payload be tuned onto an already-accepted
+/// fingerprint (T-QT-02).
+fn fingerprint(matched_text: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(matched_text.as_bytes());
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+/// Strips exactly one leading `./`, leaving an already-relative path
+/// untouched.
+///
+/// The installed pre-commit hook runs `check .` from inside a staging copy,
+/// so hook-generated paths carry the `./` prefix while `check docs/foo.md`
+/// does not. A baseline written by one and consumed by the other must agree
+/// on the path key, or the baseline is useless in the exact workflow it
+/// exists for.
+fn normalise_file(path: &str) -> String {
+    path.strip_prefix("./").unwrap_or(path).to_string()
+}
+
+impl Baseline {
+    /// Builds a baseline from a set of reports' `matches` only.
+    ///
+    /// `suppressed` and `low_confidence` are already withheld by other
+    /// mechanisms and are not the user's accept-this decision, so they are
+    /// not eligible to become baseline entries. Entries are grouped by the
+    /// identity triple, with `count` set to the number of occurrences seen
+    /// and `first_seen_line` set to the lowest line number in the group.
+    /// Entries are sorted by `(file, pattern_id, digest)` so the file is
+    /// stable and diffable across runs — an adoption artifact that reorders
+    /// itself produces noise in every PR.
+    pub fn from_reports(reports: &[ScanReport]) -> Baseline {
+        let mut groups: HashMap<Identity, (usize, usize)> = HashMap::new();
+
+        for report in reports {
+            for m in &report.matches {
+                let identity = Identity {
+                    file: normalise_file(&m.file),
+                    pattern_id: m.pattern_id.clone(),
+                    digest: fingerprint(&m.matched_text),
+                };
+                let slot = groups.entry(identity).or_insert((0, m.line));
+                slot.0 += 1;
+                if m.line < slot.1 {
+                    slot.1 = m.line;
+                }
+            }
+        }
+
+        let mut entries: Vec<BaselineEntry> = groups
+            .into_iter()
+            .map(|(identity, (count, first_seen_line))| BaselineEntry {
+                file: identity.file,
+                pattern_id: identity.pattern_id,
+                digest: identity.digest,
+                count,
+                first_seen_line,
+            })
+            .collect();
+        entries.sort_by(|a, b| {
+            (a.file.as_str(), a.pattern_id.as_str(), a.digest.as_str()).cmp(&(
+                b.file.as_str(),
+                b.pattern_id.as_str(),
+                b.digest.as_str(),
+            ))
+        });
+
+        Baseline {
+            version: CURRENT_VERSION,
+            generated_by: format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
+            entries,
+        }
+    }
+
+    /// Writes the baseline as pretty JSON with a trailing newline.
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let json = serde_json::to_string_pretty(self).context("Failed to serialize baseline")?;
+        std::fs::write(path, format!("{json}\n"))
+            .with_context(|| format!("Failed to write baseline to {}", path.display()))
+    }
+
+    /// Reads and parses a baseline file, rejecting any version other than
+    /// [`CURRENT_VERSION`].
+    ///
+    /// A malformed, missing, or unknown-version baseline is a hard error —
+    /// never a silent no-op. A silently-ignored baseline would let a
+    /// repository believe it is gated when it is not.
+    pub fn load(path: &Path) -> Result<Baseline> {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read baseline file {}", path.display()))?;
+        let baseline: Baseline = serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse baseline file {}", path.display()))?;
+        if baseline.version != CURRENT_VERSION {
+            anyhow::bail!(
+                "Baseline file {} declares version {}, but this build only understands \
+                 version {}. Regenerate it with --write-baseline.",
+                path.display(),
+                baseline.version,
+                CURRENT_VERSION
+            );
+        }
+        Ok(baseline)
+    }
+
+    /// Moves every finding whose fingerprint is in this baseline out of
+    /// `matches` and into `baselined`, rebuilding each report through
+    /// [`ScanReport::with_baselined`] so the severity tallies are recomputed
+    /// over the reduced `matches`.
+    ///
+    /// A per-fingerprint `count` budget bounds acceptance: occurrence N+1
+    /// beyond the recorded `count` stays in `matches` and still fails the
+    /// build (T-QT-03). Matches are walked in the order the scanner produced
+    /// them, so which occurrence stays visible when the budget runs out is
+    /// stable across runs.
+    ///
+    /// Returns the entries whose budget was never touched at all — zero
+    /// occurrences consumed — which is the definition of stale used to
+    /// surface the prunable-entry note.
+    pub fn apply(&self, reports: &mut [ScanReport]) -> Vec<BaselineEntry> {
+        let mut budget: HashMap<Identity, usize> = HashMap::new();
+        for entry in &self.entries {
+            budget.insert(
+                Identity {
+                    file: normalise_file(&entry.file),
+                    pattern_id: entry.pattern_id.clone(),
+                    digest: entry.digest.clone(),
+                },
+                entry.count,
+            );
+        }
+        let mut touched: HashSet<Identity> = HashSet::new();
+
+        for report in reports.iter_mut() {
+            let mut kept = Vec::new();
+            let mut baselined = std::mem::take(&mut report.baselined);
+
+            for m in std::mem::take(&mut report.matches) {
+                let identity = Identity {
+                    file: normalise_file(&m.file),
+                    pattern_id: m.pattern_id.clone(),
+                    digest: fingerprint(&m.matched_text),
+                };
+                let has_budget = budget
+                    .get(&identity)
+                    .is_some_and(|remaining| *remaining > 0);
+                if has_budget {
+                    if let Some(remaining) = budget.get_mut(&identity) {
+                        *remaining -= 1;
+                    }
+                    touched.insert(identity);
+                    baselined.push(m);
+                } else {
+                    kept.push(m);
+                }
+            }
+
+            let file = std::mem::take(&mut report.file);
+            let suppressed = std::mem::take(&mut report.suppressed);
+            let low_confidence = std::mem::take(&mut report.low_confidence);
+            *report = ScanReport::with_baselined(file, kept, suppressed, low_confidence, baselined);
+        }
+
+        self.entries
+            .iter()
+            .filter(|entry| {
+                let identity = Identity {
+                    file: normalise_file(&entry.file),
+                    pattern_id: entry.pattern_id.clone(),
+                    digest: entry.digest.clone(),
+                };
+                !touched.contains(&identity)
+            })
+            .cloned()
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_is_deterministic_prefixed_and_sensitive_to_one_character() {
+        let a = fingerprint("ignore all previous instructions");
+        let b = fingerprint("ignore all previous instructions");
+        let c = fingerprint("ignore all previous instructionZ");
+
+        assert_eq!(a, b, "the same input must hash the same way every time");
+        assert!(
+            a.starts_with("sha256:"),
+            "the digest must be prefixed sha256: so a future algorithm change is \
+             self-describing: got {a}"
+        );
+        let hex = a.strip_prefix("sha256:").expect("prefix checked above");
+        assert_eq!(
+            hex.len(),
+            64,
+            "sha256 hex-encodes to 64 lowercase characters: got {hex} ({} chars)",
+            hex.len()
+        );
+        assert!(
+            hex.chars()
+                .all(|ch| ch.is_ascii_hexdigit() && !ch.is_ascii_uppercase()),
+            "the hex must be lowercase: got {hex}"
+        );
+        assert_ne!(
+            a, c,
+            "a one-character-different input must not collide — a weak/predictable \
+             digest would let an attacker tune a new payload onto an accepted fingerprint"
+        );
+    }
+
+    #[test]
+    fn normalise_file_strips_exactly_one_leading_dot_slash() {
+        assert_eq!(
+            normalise_file("./docs/foo.md"),
+            "docs/foo.md",
+            "the pre-commit hook runs `check .`, which reports paths with a leading \
+             ./ — a baseline that does not strip it can never match that invocation"
+        );
+        assert_eq!(
+            normalise_file("docs/foo.md"),
+            "docs/foo.md",
+            "an already-relative path must be left untouched"
+        );
+        assert_eq!(
+            normalise_file("././docs/foo.md"),
+            "./docs/foo.md",
+            "only ONE leading ./ is stripped, not repeated ones"
+        );
+    }
+}

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -47,7 +47,13 @@ pub struct BaselineEntry {
 /// The top-level shape here is a JSON *object*, not an array — this is a new
 /// artifact and is unrelated to the `--format json` report stream, whose
 /// array-at-top-level contract `spec-ci-plugin` depends on is untouched.
+///
+/// `#[serde(deny_unknown_fields)]` for the same reason `BaselineEntry` carries
+/// it: a file that parses despite a key its author misspelled does not mean
+/// what they think it means, and the gap only shows up as findings that stop
+/// being gated.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Baseline {
     pub version: u32,
     #[serde(default)]
@@ -84,11 +90,11 @@ fn fingerprint(matched_text: &str) -> String {
 /// Strips exactly one leading `./`, leaving an already-relative path
 /// untouched.
 ///
-/// The installed pre-commit hook runs `check .` from inside a staging copy,
-/// so hook-generated paths carry the `./` prefix while `check docs/foo.md`
-/// does not. A baseline written by one and consumed by the other must agree
-/// on the path key, or the baseline is useless in the exact workflow it
-/// exists for.
+/// `check .` reports paths with a leading `./` while `check docs/foo.md`
+/// reports the bare path, and the installed pre-commit hook uses the `check .`
+/// form (from inside a staging copy). A baseline written by one invocation and
+/// consumed by the other must agree on the path key, or the two shapes never
+/// match and the baseline looks broken for no visible reason.
 fn normalise_file(path: &str) -> String {
     path.strip_prefix("./").unwrap_or(path).to_string()
 }
@@ -194,14 +200,17 @@ impl Baseline {
     pub fn apply(&self, reports: &mut [ScanReport]) -> Vec<BaselineEntry> {
         let mut budget: HashMap<Identity, usize> = HashMap::new();
         for entry in &self.entries {
-            budget.insert(
-                Identity {
+            // Summed, not overwritten. A hand-edited or concatenated baseline
+            // can list one identity twice; taking only the last count would
+            // silently accept fewer occurrences than the file plainly grants,
+            // and the surplus would surface as findings with no explanation.
+            *budget
+                .entry(Identity {
                     file: normalise_file(&entry.file),
                     pattern_id: entry.pattern_id.clone(),
                     digest: entry.digest.clone(),
-                },
-                entry.count,
-            );
+                })
+                .or_insert(0) += entry.count;
         }
         let mut touched: HashSet<Identity> = HashSet::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![deny(clippy::unwrap_used)]
 
 pub mod allowlist;
+pub mod baseline;
 pub mod context;
 pub mod multiline;
 pub mod normalize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 
 use injection_scanner::allowlist::{parse_suppressions, Suppressions};
+use injection_scanner::baseline::Baseline;
 use injection_scanner::context::DEFAULT_MIN_CONFIDENCE;
 use injection_scanner::pattern::{ScanReport, Severity};
 use injection_scanner::patterns::load_all_patterns;
@@ -187,6 +188,24 @@ enum Commands {
         /// did not assemble, where the extension tells you nothing.
         #[arg(long)]
         all_files: bool,
+
+        // ---- incremental adoption (issue #25, CLI-08) ----
+        /// Withhold findings already accepted in this baseline file
+        ///
+        /// An existing repository cannot adopt this scanner if day one is a
+        /// wall of findings. Findings whose fingerprint is recorded here are
+        /// moved out of `matches` and into `baselined`; they do not affect
+        /// the exit code. Generate one with --write-baseline first.
+        #[arg(long, value_name = "FILE")]
+        baseline: Option<PathBuf>,
+        /// Scan, then record every finding as accepted into this file
+        ///
+        /// Means "accept the current state" — this always exits 0, even when
+        /// CRITICAL findings were found, because writing the baseline IS the
+        /// decision. Not valid with `check -`: stdin has no stable file
+        /// identity to record a baseline against.
+        #[arg(long, value_name = "FILE", conflicts_with = "baseline")]
+        write_baseline: Option<PathBuf>,
     },
     /// List every loaded pattern
     Rules {
@@ -288,8 +307,20 @@ fn main() -> Result<()> {
             all_files,
             fail_on,
             quiet,
+            baseline,
+            write_baseline,
         } => {
             let min_confidence = resolve_min_confidence(strict, min_confidence)?;
+
+            // Fail before stdin is consumed so a piped producer sees the
+            // error rather than a closed pipe.
+            if path == "-" && write_baseline.is_some() {
+                anyhow::bail!(
+                    "--write-baseline is not valid with `check -`: stdin has no stable file \
+                     identity to record a baseline against."
+                );
+            }
+
             let loaded = load_all_patterns(patterns.as_deref())
                 .context("Failed to load embedded patterns")?;
             let categories = loaded.categories;
@@ -441,6 +472,48 @@ fn main() -> Result<()> {
                 }
             }
 
+            // `--write-baseline` means "accept the current state": write the
+            // baseline, show the run exactly as an unflagged one would, and
+            // exit CLEAN even though CRITICAL findings may be present — that
+            // is the whole point of the flag (D-2).
+            if let Some(write_baseline_path) = &write_baseline {
+                let baseline = Baseline::from_reports(&reports);
+                baseline.save(write_baseline_path).with_context(|| {
+                    format!(
+                        "Failed to write baseline to {}",
+                        write_baseline_path.display()
+                    )
+                })?;
+
+                let output = match format {
+                    OutputFormat::Json => format_json(&reports)?,
+                    OutputFormat::Text => format_text(&reports),
+                };
+                if !quiet {
+                    print!("{}", output);
+                    eprintln!(
+                        "note: wrote {} baseline entr{} to {}",
+                        baseline.entries.len(),
+                        if baseline.entries.len() == 1 {
+                            "y"
+                        } else {
+                            "ies"
+                        },
+                        write_baseline_path.display()
+                    );
+                }
+                std::process::exit(exit::CLEAN);
+            }
+
+            // `--baseline` moves accepted findings out of `matches` before
+            // anything downstream — formatting, the stderr notes, and the
+            // exit-code walk below — ever sees them.
+            let mut stale_entries = Vec::new();
+            if let Some(baseline_path) = &baseline {
+                let loaded = Baseline::load(baseline_path)?;
+                stale_entries = loaded.apply(&mut reports);
+            }
+
             // Exhaustive by construction — a new variant will not compile until
             // it has a writer, which is the point of the enum.
             let output = match format {
@@ -450,6 +523,20 @@ fn main() -> Result<()> {
 
             if !quiet {
                 print!("{}", output);
+            }
+
+            // A stale entry is a live licence to re-introduce the finding it
+            // once accepted, so it is named — not just counted — so it can be
+            // pruned from the committed file.
+            if !quiet {
+                for entry in &stale_entries {
+                    eprintln!(
+                        "note: baseline entry {} in {} matched nothing this run and can be \
+                         pruned — an entry matching nothing is a standing licence to \
+                         re-introduce the finding it once accepted.",
+                        entry.pattern_id, entry.file
+                    );
+                }
             }
 
             if skipped > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@
 
 use std::fs;
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
@@ -224,6 +224,15 @@ enum Commands {
         /// Severity at or above which a commit is blocked
         #[arg(long, value_enum, ignore_case = true, default_value_t = FailOn::High)]
         fail_on: FailOn,
+        /// Honour this baseline file when the hook scans (issue #25, CLI-08)
+        ///
+        /// Without it, a repository that accepted its existing findings with
+        /// `check . --write-baseline` still cannot commit: the hook would
+        /// re-report every one of them. The path is resolved to an absolute
+        /// one at install time, because the hook scans from inside a temporary
+        /// staging copy where a relative path would not exist.
+        #[arg(long, value_name = "FILE")]
+        baseline: Option<PathBuf>,
         /// Overwrite an existing hook
         #[arg(long)]
         force: bool,
@@ -491,6 +500,16 @@ fn main() -> Result<()> {
                 };
                 if !quiet {
                     print!("{}", output);
+                    // Before the confirmation, not after. Recording an accept
+                    // decision over a tree the scanner could not fully read is
+                    // exactly when the coverage gap matters most, and the
+                    // reassuring "wrote N entries" must not be the last word.
+                    if skipped > 0 {
+                        eprintln!(
+                            "warning: {} file(s) skipped and NOT scanned — they are NOT in this                              baseline; see warnings above",
+                            skipped
+                        );
+                    }
                     eprintln!(
                         "note: wrote {} baseline entr{} to {}",
                         baseline.entries.len(),
@@ -592,8 +611,23 @@ fn main() -> Result<()> {
         Commands::InstallHook {
             repo,
             fail_on,
+            baseline,
             force,
         } => {
+            // Resolved before anything is written. A hook baked with a
+            // mistyped path would fail on every commit from then on, and the
+            // error would surface far from the typo that caused it.
+            let baseline = match baseline {
+                None => None,
+                Some(path) => Some(fs::canonicalize(&path).with_context(|| {
+                    format!(
+                        "Cannot install a hook against baseline {} — write one first with \
+                         `injection-scanner check . --write-baseline {}`",
+                        path.display(),
+                        path.display()
+                    )
+                })?),
+            };
             let root = repo.unwrap_or_else(|| PathBuf::from("."));
             let hooks = git_hooks_dir(&root)?;
             let hook = hooks.join("pre-commit");
@@ -617,7 +651,7 @@ fn main() -> Result<()> {
 
             fs::create_dir_all(&hooks)
                 .with_context(|| format!("Failed to create {}", hooks.display()))?;
-            fs::write(&hook, hook_script(fail_on))
+            fs::write(&hook, hook_script(fail_on, baseline.as_deref()))
                 .with_context(|| format!("Failed to write {}", hook.display()))?;
 
             #[cfg(unix)]
@@ -631,6 +665,9 @@ fn main() -> Result<()> {
             println!(
                 "Staged files are scanned before each commit; {fail_on:?} and above block it."
             );
+            if let Some(path) = &baseline {
+                println!("Findings accepted in {} are not reported.", path.display());
+            }
             println!("Bypass once with `git commit --no-verify`.");
         }
 
@@ -762,8 +799,30 @@ fn git_hooks_dir(root: &std::path::Path) -> Result<PathBuf> {
 /// working tree — `git stash`-free and correct when a file is partially staged.
 /// Without that, a developer could stage a clean version, leave a payload
 /// unstaged, and have the hook pass on text that is not what gets committed.
-fn hook_script(fail_on: FailOn) -> String {
+/// Wraps `value` in single quotes for safe interpolation into the generated
+/// `sh` hook.
+///
+/// The hook is a file we write and a shell later executes, so an unquoted path
+/// containing a space, a `$` or a `;` would be re-parsed as shell syntax. POSIX
+/// single quotes protect everything except a single quote itself, which is
+/// closed, escaped and reopened in the usual way.
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+fn hook_script(fail_on: FailOn, baseline: Option<&Path>) -> String {
     let bar = format!("{fail_on:?}").to_lowercase();
+    // The hook runs `cd "$tmp" && injection-scanner check .`, so the baseline
+    // path must be absolute — a relative one would resolve inside the throwaway
+    // staging copy and not exist. `install-hook` canonicalises it before we get
+    // here; this only has to survive the trip through `sh`.
+    let baseline_arg = match baseline {
+        None => String::new(),
+        Some(path) => format!(
+            " --baseline {}",
+            shell_single_quote(&path.to_string_lossy())
+        ),
+    };
     format!(
         r##"#!/bin/sh
 # {HOOK_MARKER}
@@ -800,7 +859,7 @@ done
 # the developer recognises, rather than at some /tmp/tmp.XXXX prefix they cannot
 # act on.
 status=0
-( cd "$tmp" && injection-scanner check . --fail-on {bar} --no-ignore ) || status=$?
+( cd "$tmp" && injection-scanner check . --fail-on {bar} --no-ignore{baseline_arg} ) || status=$?
 
 if [ "$status" -eq 1 ]; then
   echo "" >&2

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -168,8 +168,25 @@ pub struct ScanReport {
     /// `spec-ci-plugin`'s `JSON.parse(output) as Array<...>` is unaffected.
     #[serde(default)]
     pub low_confidence: Vec<ScanMatch>,
+    /// Findings withheld because a `--baseline <FILE>` accepted them in a
+    /// prior run.
+    ///
+    /// Deliberately the **same** `ScanMatch` the `matches` array holds, filed
+    /// under a THIRD distinct reason a finding can be withheld: `suppressed`
+    /// means the scanned document disarmed the scanner, `low_confidence`
+    /// means the scanner judged it documentation, and `baselined` means a
+    /// human accepted it once and recorded that decision in a committed
+    /// baseline file. Recorded rather than discarded, for the same reason
+    /// the other two are: a decision worth acting on is a decision worth
+    /// being able to see.
+    ///
+    /// Additive field — the top-level JSON stays an array of report objects,
+    /// so `spec-ci-plugin`'s `JSON.parse(output) as Array<...>` is unaffected.
+    #[serde(default)]
+    pub baselined: Vec<ScanMatch>,
     /// Severity tallies over `matches` **only** — suppressed findings are not
-    /// counted here, and neither are `low_confidence` ones.
+    /// counted here, neither are `low_confidence` ones, nor are `baselined`
+    /// ones.
     ///
     /// These answer "what is the user being asked to act on", which is what
     /// drives exit codes and CI gates; a suppressed finding is by definition
@@ -208,6 +225,23 @@ impl ScanReport {
         suppressed: Vec<ScanMatch>,
         low_confidence: Vec<ScanMatch>,
     ) -> Self {
+        Self::with_baselined(file, matches, suppressed, low_confidence, Vec::new())
+    }
+
+    /// Create a report recording all three reasons a finding can be
+    /// withheld, including baseline acceptance.
+    ///
+    /// The only constructor that recomputes the severity tallies — a
+    /// baselined finding must move through here, not be spliced into an
+    /// already-built report, because these tallies are what drive the exit
+    /// code and CI gates.
+    pub fn with_baselined(
+        file: String,
+        matches: Vec<ScanMatch>,
+        suppressed: Vec<ScanMatch>,
+        low_confidence: Vec<ScanMatch>,
+        baselined: Vec<ScanMatch>,
+    ) -> Self {
         let critical_count = matches
             .iter()
             .filter(|m| m.severity == Severity::Critical)
@@ -229,6 +263,7 @@ impl ScanReport {
             matches,
             suppressed,
             low_confidence,
+            baselined,
             critical_count,
             high_count,
             medium_count,
@@ -249,6 +284,11 @@ impl ScanReport {
     /// How many findings the markdown-context threshold withheld.
     pub fn low_confidence_count(&self) -> usize {
         self.low_confidence.len()
+    }
+
+    /// How many findings a `--baseline` file withheld.
+    pub fn baselined_count(&self) -> usize {
+        self.baselined.len()
     }
 }
 

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -35,6 +35,7 @@ pub fn format_text(reports: &[ScanReport]) -> String {
 
     let total_suppressed: usize = reports.iter().map(|r| r.suppressed_count()).sum();
     let total_low_confidence: usize = reports.iter().map(|r| r.low_confidence_count()).sum();
+    let total_baselined: usize = reports.iter().map(|r| r.baselined_count()).sum();
     let total_critical: usize = reports.iter().map(|r| r.critical_count).sum();
     let total_high: usize = reports.iter().map(|r| r.high_count).sum();
     let total_medium: usize = reports.iter().map(|r| r.medium_count).sum();
@@ -45,7 +46,7 @@ pub fn format_text(reports: &[ScanReport]) -> String {
         // Not flatly "nothing detected" when something *was* detected and then
         // withheld — that reads as a clean bill of health, and the line below
         // would contradict it.
-        if total_low_confidence > 0 || total_suppressed > 0 {
+        if total_low_confidence > 0 || total_suppressed > 0 || total_baselined > 0 {
             output.push_str("No injection patterns reported.\n");
         } else {
             output.push_str("No injection patterns detected.\n");
@@ -92,6 +93,21 @@ pub fn format_text(reports: &[ScanReport]) -> String {
         output.push_str(&format!(
             "{total_low_confidence} {findings} withheld as documentation (code blocks, inline \
              spans, tables). Re-run with --strict to see {them}.\n"
+        ));
+    }
+
+    // A baseline is an accept-risk decision recorded in a committed file, not
+    // a property of the scanned document or the scanner's own judgement — so
+    // it gets a third, separate note, in the same voice as the two above.
+    if total_baselined > 0 {
+        let (findings, them) = if total_baselined == 1 {
+            ("finding", "it")
+        } else {
+            ("findings", "them")
+        };
+        output.push_str(&format!(
+            "{total_baselined} {findings} accepted by the baseline. Re-run without --baseline \
+             to see {them}.\n"
         ));
     }
 

--- a/tests/baseline_test.rs
+++ b/tests/baseline_test.rs
@@ -1,0 +1,169 @@
+//! `--baseline` / `--write-baseline` (issue #25, CLI-08).
+//!
+//! An existing repository cannot adopt this scanner if day one is a wall of
+//! findings. A baseline is the standard answer: accept the current state once,
+//! then only new findings fail the build. This file guards the two-command
+//! adoption flow end to end, plus the adversarial edges that would make the
+//! feature unsafe — an unbounded accept, a fingerprint an attacker can retune,
+//! a silently-ignored malformed baseline, and a stale entry nobody notices.
+//!
+//! Spawns the real binary via `env!("CARGO_BIN_EXE_injection-scanner")` —
+//! never a hand-built target-directory path; `test_harness_contract_test.rs`
+//! fails the build otherwise.
+
+use std::io::Write;
+use std::process::Command;
+
+fn binary() -> &'static str {
+    env!("CARGO_BIN_EXE_injection-scanner")
+}
+
+/// A temp file that cleans itself up.
+struct Doc(std::path::PathBuf);
+
+impl Doc {
+    fn new(name: &str, content: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "injscan-baseline-{}-{}-{name}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let mut file = std::fs::File::create(&path).expect("create");
+        file.write_all(content.as_bytes()).expect("write");
+        Self(path)
+    }
+    fn path(&self) -> &str {
+        self.0.to_str().expect("utf-8 path")
+    }
+    fn write(&self, content: &str) {
+        std::fs::write(&self.0, content).expect("overwrite");
+    }
+}
+
+impl Drop for Doc {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+/// Cheap per-call uniqueness so parallel tests in this file never collide on
+/// the same temp path.
+fn unique_suffix() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+fn run(args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(binary()).args(args).output().expect("run");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn fixture_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/injected-skill.md")
+}
+
+/// The substring that makes the fixture a finding, read once from the fixture
+/// itself so this file never re-types an injection payload.
+fn fixture_payload_substring() -> String {
+    let content = std::fs::read_to_string(fixture_path()).expect("fixture must be readable");
+    content
+        .lines()
+        .find(|line| {
+            line.to_lowercase()
+                .contains("ignore all previous instructions")
+        })
+        .expect("fixture must contain the line this test keys on")
+        .trim()
+        .to_string()
+}
+
+fn baseline_path(name: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "injscan-baseline-file-{}-{}-{name}.json",
+        std::process::id(),
+        unique_suffix()
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Task 1 — the tracer: write it, then re-scan clean.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_two_command_adoption_flow_works_end_to_end() {
+    let fixture = fixture_path();
+    let fixture = fixture.to_str().expect("utf-8 path");
+    let baseline = baseline_path("tracer");
+
+    // Step 0: unbaselined, the fixture fails the build.
+    let (code, _, _) = run(&["check", fixture, "--quiet"]);
+    assert_eq!(
+        code, 1,
+        "the fixture must contain at least one finding for this test to mean anything"
+    );
+
+    // Step 1: --write-baseline accepts the current state and exits CLEAN.
+    let (code, _, _) = run(&[
+        "check",
+        fixture,
+        "--write-baseline",
+        baseline.to_str().expect("utf-8 path"),
+        "--quiet",
+    ]);
+    assert_eq!(
+        code, 0,
+        "--write-baseline means \"accept the current state\" and must exit 0 even though \
+         the scan found CRITICAL findings — that is the entire point of D-2"
+    );
+    assert!(
+        baseline.exists(),
+        "--write-baseline must create the file at the given path"
+    );
+
+    // Step 2: re-scanning with --baseline moves the findings out of `matches`.
+    let (code, stdout, _) = run(&[
+        "check",
+        fixture,
+        "--baseline",
+        baseline.to_str().expect("utf-8 path"),
+        "--format",
+        "json",
+    ]);
+    assert_eq!(
+        code, 0,
+        "every finding was baselined, so the exit code must read as clean"
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let reports = parsed.as_array().expect("top level must be an array");
+    let report = reports
+        .iter()
+        .find(|r| r["file"].as_str() == Some(fixture))
+        .expect("the fixture's report must be present");
+
+    assert!(
+        report["matches"]
+            .as_array()
+            .expect("matches is array")
+            .is_empty(),
+        "a fully-baselined file must have an empty `matches`: {report}"
+    );
+    assert!(
+        !report["baselined"]
+            .as_array()
+            .expect("baselined is array — the array must exist and be populated")
+            .is_empty(),
+        "the baselined findings must be recorded somewhere, not silently dropped: {report}"
+    );
+    assert_eq!(
+        report["critical_count"], 0,
+        "a baselined CRITICAL must not be counted in the severity tallies: {report}"
+    );
+
+    let _ = std::fs::remove_file(&baseline);
+}

--- a/tests/baseline_test.rs
+++ b/tests/baseline_test.rs
@@ -633,3 +633,108 @@ fn baselined_findings_carry_full_evidence_and_the_top_level_stays_an_array() {
 
     let _ = std::fs::remove_file(&baseline);
 }
+
+// ---- review follow-ups ----
+
+#[test]
+fn writing_a_baseline_still_reports_that_files_went_unscanned() {
+    // `--write-baseline` exits early to force exit code 0, and in doing so it
+    // used to jump over the "N file(s) skipped and NOT scanned" summary. That
+    // summary is deliberately the LAST line of a normal run so it cannot be
+    // missed; losing it here means accepting a baseline while being told less
+    // about the gaps in it than an ordinary scan would tell you.
+    let dir = std::env::temp_dir().join(format!(
+        "injscan-baseline-skip-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create tempdir");
+    std::fs::copy(fixture_path(), dir.join("a.md")).expect("copy fixture");
+    // Invalid UTF-8: unreadable as text, so the walker skips it.
+    std::fs::write(dir.join("binary.md"), [0xff, 0xfe, 0x00, 0x01]).expect("write binary");
+    let baseline = dir.join("b.json");
+
+    let (code, _, stderr) = run(&[
+        "check",
+        dir.to_str().expect("utf-8 path"),
+        "--write-baseline",
+        baseline.to_str().expect("utf-8 path"),
+    ]);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(code, 0, "--write-baseline must still exit 0: {stderr}");
+    assert!(
+        stderr.contains("file(s) skipped and NOT scanned"),
+        "a baseline written over a tree with unscanned files must say so — the \
+         user is recording an accept decision over coverage they do not have. \
+         stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn an_unknown_top_level_field_in_a_baseline_is_rejected() {
+    // `BaselineEntry` already denies unknown fields on exactly this reasoning:
+    // a mistyped key must fail the parse rather than yield a file that quietly
+    // means something other than what its author wrote. The same argument
+    // applies one level up.
+    let doc = Doc::new("unknown-field.md", "clean prose, nothing to find here\n");
+    let baseline = Doc::new(
+        "unknown-field-baseline.json",
+        r#"{"version":1,"generated_by":"x","entries":[],"entires":[]}"#,
+    );
+
+    let (code, stdout, stderr) = run(&["check", doc.path(), "--baseline", baseline.path()]);
+
+    assert_ne!(
+        code, 0,
+        "an unrecognised top-level key means the file does not say what its \
+         author thinks it says — parsing it anyway is how a baseline silently \
+         stops gating. stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(baseline.path()),
+        "the error must name the offending file: {stderr}"
+    );
+}
+
+#[test]
+fn duplicate_entries_for_one_fingerprint_sum_their_counts() {
+    // A hand-edited or concatenated baseline can carry the same identity twice.
+    // Overwriting rather than summing silently narrows the accepted budget, so
+    // findings the file plainly accepts get reported anyway — confusing, and it
+    // trains people to distrust the tool. Two entries of count 1 mean two.
+    let payload = std::fs::read_to_string(fixture_path()).expect("read fixture");
+    let doc = Doc::new("dup-entries.md", &format!("{payload}\n{payload}\n"));
+    let written = Doc::new("dup-entries-baseline.json", "{}");
+
+    // Write a baseline that accepts BOTH occurrences, then split each entry
+    // into two entries of half the count. Summing must be equivalent.
+    let (code, _, stderr) = run(&["check", doc.path(), "--write-baseline", written.path()]);
+    assert_eq!(code, 0, "--write-baseline must exit 0: {stderr}");
+
+    let raw = std::fs::read_to_string(&written.0).expect("read baseline");
+    let mut value: serde_json::Value = serde_json::from_str(&raw).expect("baseline is JSON");
+    let entries = value["entries"].as_array().expect("entries array").clone();
+    let mut split = Vec::new();
+    for entry in entries {
+        let count = entry["count"].as_u64().expect("count");
+        assert_eq!(
+            count, 2,
+            "the fixture was duplicated, so each fingerprint should be accepted twice"
+        );
+        let mut half = entry.clone();
+        half["count"] = serde_json::json!(1);
+        split.push(half.clone());
+        split.push(half);
+    }
+    value["entries"] = serde_json::Value::Array(split);
+    written.write(&serde_json::to_string_pretty(&value).expect("re-serialize"));
+
+    let (code, stdout, stderr) = run(&["check", doc.path(), "--baseline", written.path()]);
+    assert_eq!(
+        code, 0,
+        "two entries of count 1 accept the same two occurrences one entry of \
+         count 2 does. stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}

--- a/tests/baseline_test.rs
+++ b/tests/baseline_test.rs
@@ -167,3 +167,469 @@ fn the_two_command_adoption_flow_works_end_to_end() {
 
     let _ = std::fs::remove_file(&baseline);
 }
+
+// ---------------------------------------------------------------------------
+// Task 2 — the adversarial edges: count, staleness, malformed input, and the
+// two rejections.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_occurrence_beyond_count_is_still_reported() {
+    let line = fixture_payload_substring();
+    let doc = Doc::new("count.md", &format!("{line}\n"));
+    let baseline = baseline_path("count");
+
+    let (code, _, _) = run(&[
+        "check",
+        doc.path(),
+        "--write-baseline",
+        baseline.to_str().expect("utf-8 path"),
+        "--quiet",
+    ]);
+    assert_eq!(code, 0, "write-baseline always exits clean");
+
+    // The same file now contains the payload twice.
+    doc.write(&format!(
+        "{line}\n\nSome unrelated clean prose sits here.\n\n{line}\n"
+    ));
+
+    let (code, stdout, _) = run(&[
+        "check",
+        doc.path(),
+        "--baseline",
+        baseline.to_str().expect("utf-8 path"),
+        "--format",
+        "json",
+    ]);
+    assert_eq!(
+        code, 1,
+        "baselining one occurrence accepts one, not an unlimited number (D-1) — the second \
+         occurrence must still fail the build"
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let reports = parsed.as_array().expect("array");
+    let report = reports
+        .iter()
+        .find(|r| r["file"].as_str() == Some(doc.path()))
+        .expect("report present");
+    assert_eq!(
+        report["matches"].as_array().expect("array").len(),
+        1,
+        "exactly one occurrence beyond the accepted count must remain reported: {report}"
+    );
+    assert_eq!(
+        report["baselined"].as_array().expect("array").len(),
+        1,
+        "exactly one occurrence must have been baselined, matching the recorded count: {report}"
+    );
+
+    let _ = std::fs::remove_file(&baseline);
+}
+
+#[test]
+fn a_stale_entry_is_surfaced_and_only_when_stale() {
+    let line = fixture_payload_substring();
+    let doc = Doc::new("stale.md", &format!("{line}\n"));
+    let baseline = baseline_path("stale");
+
+    run(&[
+        "check",
+        doc.path(),
+        "--write-baseline",
+        baseline.to_str().expect("utf-8 path"),
+        "--quiet",
+    ]);
+
+    // Control: the entry still matches, so the note must be ABSENT — otherwise
+    // this test could pass vacuously against a note printed unconditionally.
+    let (code, _, stderr) = run(&[
+        "check",
+        doc.path(),
+        "--baseline",
+        baseline.to_str().expect("utf-8 path"),
+    ]);
+    assert_eq!(code, 0);
+    assert!(
+        !stderr.contains("can be pruned"),
+        "an entry that matched must NOT be reported stale: {stderr}"
+    );
+
+    // Now the document goes clean — the baseline entry matches nothing.
+    doc.write("nothing suspicious here at all\n");
+    let (code, _, stderr) = run(&[
+        "check",
+        doc.path(),
+        "--baseline",
+        baseline.to_str().expect("utf-8 path"),
+    ]);
+    assert_eq!(code, 0, "a stale baseline entry does not fail the build");
+    assert!(
+        stderr.contains("PI001"),
+        "the stale note must name the pattern_id: {stderr}"
+    );
+    assert!(
+        stderr.contains(doc.path()),
+        "the stale note must name the file: {stderr}"
+    );
+    assert!(
+        stderr.contains("pruned"),
+        "the note must say the entry can be pruned, not just that it exists: {stderr}"
+    );
+
+    let _ = std::fs::remove_file(&baseline);
+}
+
+#[test]
+fn editing_lines_above_a_finding_does_not_invalidate_its_baseline_entry() {
+    let line = fixture_payload_substring();
+    let doc = Doc::new("lines-move.md", &format!("{line}\n"));
+    let baseline = baseline_path("lines-move");
+
+    run(&[
+        "check",
+        doc.path(),
+        "--write-baseline",
+        baseline.to_str().expect("utf-8 path"),
+        "--quiet",
+    ]);
+
+    doc.write(&format!(
+        "Some clean prose.\nMore clean prose.\nEven more of it.\n\n{line}\n"
+    ));
+
+    let (code, stdout, _) = run(&[
+        "check",
+        doc.path(),
+        "--baseline",
+        baseline.to_str().expect("utf-8 path"),
+        "--format",
+        "json",
+    ]);
+    assert_eq!(
+        code, 0,
+        "editing lines above a finding must not invalidate its baseline entry (D-1) — line \
+         number is not part of identity"
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let reports = parsed.as_array().expect("array");
+    let report = reports
+        .iter()
+        .find(|r| r["file"].as_str() == Some(doc.path()))
+        .expect("report present");
+    assert!(
+        !report["baselined"].as_array().expect("array").is_empty(),
+        "the finding must still be baselined after prose was inserted above it: {report}"
+    );
+
+    let _ = std::fs::remove_file(&baseline);
+}
+
+#[test]
+fn a_baseline_that_is_not_json_is_a_hard_error() {
+    let bad = baseline_path("not-json");
+    std::fs::write(&bad, "this is not json at all\n").expect("write");
+    let doc = Doc::new("target-a.md", "nothing suspicious here\n");
+
+    let (code, stdout, stderr) = run(&[
+        "check",
+        doc.path(),
+        "--baseline",
+        bad.to_str().expect("utf-8 path"),
+    ]);
+    assert_ne!(
+        code, 0,
+        "a malformed baseline must be a hard error — a repository must not believe it is \
+         gated when it is not"
+    );
+    assert!(
+        stdout.is_empty(),
+        "no scan report should print when the baseline itself failed to load: {stdout:?}"
+    );
+    assert!(
+        stderr.contains(bad.to_str().expect("utf-8 path")),
+        "stderr must name the offending path: {stderr}"
+    );
+
+    let _ = std::fs::remove_file(&bad);
+}
+
+#[test]
+fn a_baseline_entry_missing_a_required_field_is_a_hard_error() {
+    let bad = baseline_path("missing-digest");
+    std::fs::write(
+        &bad,
+        r#"{"version":1,"entries":[{"file":"x.md","pattern_id":"PI001","count":1}]}"#,
+    )
+    .expect("write");
+    let doc = Doc::new("target-b.md", "nothing suspicious here\n");
+
+    let (code, stdout, stderr) = run(&[
+        "check",
+        doc.path(),
+        "--baseline",
+        bad.to_str().expect("utf-8 path"),
+    ]);
+    assert_ne!(
+        code, 0,
+        "an entry missing `digest` must fail the parse rather than silently match nothing"
+    );
+    assert!(stdout.is_empty(), "{stdout:?}");
+    assert!(
+        stderr.contains(bad.to_str().expect("utf-8 path")),
+        "{stderr}"
+    );
+
+    let _ = std::fs::remove_file(&bad);
+}
+
+#[test]
+fn a_baseline_with_an_unrecognised_version_is_a_hard_error() {
+    let bad = baseline_path("bad-version");
+    std::fs::write(&bad, r#"{"version":99,"entries":[]}"#).expect("write");
+    let doc = Doc::new("target-c.md", "nothing suspicious here\n");
+
+    let (code, stdout, stderr) = run(&[
+        "check",
+        doc.path(),
+        "--baseline",
+        bad.to_str().expect("utf-8 path"),
+    ]);
+    assert_ne!(
+        code, 0,
+        "an unrecognised baseline version must be a hard error"
+    );
+    assert!(stdout.is_empty(), "{stdout:?}");
+    assert!(
+        stderr.contains("99") && stderr.to_lowercase().contains("version"),
+        "stderr must name both the found and expected version: {stderr}"
+    );
+
+    let _ = std::fs::remove_file(&bad);
+}
+
+#[test]
+fn a_nonexistent_baseline_path_is_a_hard_error() {
+    let missing = baseline_path("does-not-exist");
+    let doc = Doc::new("target-d.md", "nothing suspicious here\n");
+
+    let (code, stdout, stderr) = run(&[
+        "check",
+        doc.path(),
+        "--baseline",
+        missing.to_str().expect("utf-8 path"),
+    ]);
+    assert_ne!(
+        code, 0,
+        "a missing baseline file must be a hard error, never a silent no-op"
+    );
+    assert!(stdout.is_empty(), "{stdout:?}");
+    assert!(
+        stderr.contains(missing.to_str().expect("utf-8 path")),
+        "stderr must name the missing path: {stderr}"
+    );
+}
+
+#[test]
+fn baseline_and_write_baseline_together_are_rejected() {
+    let doc = Doc::new("both-flags.md", "nothing suspicious here\n");
+    let a = baseline_path("both-a");
+    let b = baseline_path("both-b");
+    let (code, _, stderr) = run(&[
+        "check",
+        doc.path(),
+        "--baseline",
+        a.to_str().expect("utf-8 path"),
+        "--write-baseline",
+        b.to_str().expect("utf-8 path"),
+    ]);
+    // Deliberately NOT asserting the specific exit code: clap's usage-error
+    // exit is 2, which would be indistinguishable from exit::BELOW_THRESHOLD.
+    assert_ne!(code, 0, "the two flags must be mutually exclusive");
+    assert!(
+        stderr.to_lowercase().contains("cannot be used with"),
+        "clap's conflict wording should explain WHY, not just fail silently: {stderr}"
+    );
+}
+
+#[test]
+fn write_baseline_with_stdin_is_rejected() {
+    let baseline = baseline_path("stdin-rejected");
+    let mut child = Command::new(binary())
+        .args([
+            "check",
+            "-",
+            "--write-baseline",
+            baseline.to_str().expect("utf-8 path"),
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    // Nothing is written to stdin — the rejection must happen before stdin is
+    // ever read, so a piped producer sees the error rather than a closed pipe.
+    // Taking (and dropping) the write half closes the pipe on this end.
+    let _ = child.stdin.take();
+    let out = child.wait_with_output().expect("wait");
+
+    assert!(
+        !out.status.success(),
+        "stdin has no stable file identity to record a baseline against"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.to_lowercase().contains("stdin"),
+        "stderr must name stdin as the reason: {stderr}"
+    );
+    assert!(
+        !baseline.exists(),
+        "the baseline file must not be created when the flag combination is rejected"
+    );
+}
+
+#[test]
+fn the_written_baseline_is_inert() {
+    let fixture = fixture_path();
+    let fixture = fixture.to_str().expect("utf-8 path");
+    let baseline = baseline_path("inert");
+    let payload = fixture_payload_substring();
+
+    run(&[
+        "check",
+        fixture,
+        "--write-baseline",
+        baseline.to_str().expect("utf-8 path"),
+        "--quiet",
+    ]);
+
+    let baseline_text = std::fs::read_to_string(&baseline).expect("baseline must be readable");
+    assert!(
+        !baseline_text.contains(&payload),
+        "the baseline must store a hash, never the payload verbatim — json is a scanned \
+         extension by default, and a committed baseline full of payloads would itself become \
+         a finding source: {baseline_text}"
+    );
+
+    let (code, _, _) = run(&[
+        "check",
+        baseline.to_str().expect("utf-8 path"),
+        "--include",
+        "**/*.json",
+        "--quiet",
+    ]);
+    assert_eq!(
+        code, 0,
+        "scanning the baseline file itself must find nothing — this is D-1's core \
+         justification, tested rather than asserted in prose"
+    );
+
+    let _ = std::fs::remove_file(&baseline);
+}
+
+#[test]
+fn the_path_key_survives_the_leading_dot_slash_prefix_from_check_dot() {
+    let tmp = std::env::temp_dir().join(format!(
+        "injscan-baseline-dotdir-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    std::fs::create_dir_all(&tmp).expect("create tempdir");
+    let line = fixture_payload_substring();
+    std::fs::write(tmp.join("skill.md"), format!("{line}\n")).expect("write");
+
+    // `check .` from inside the temp directory — exactly the shape the
+    // installed pre-commit hook uses.
+    let out = Command::new(binary())
+        .current_dir(&tmp)
+        .args(["check", ".", "--write-baseline", "baseline.json", "--quiet"])
+        .output()
+        .expect("run");
+    assert_eq!(out.status.code(), Some(0));
+
+    let out = Command::new(binary())
+        .current_dir(&tmp)
+        .args([
+            "check",
+            ".",
+            "--baseline",
+            "baseline.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("run");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "the baseline written by `check .` must be usable by a later `check .`"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let reports = parsed.as_array().expect("array");
+    let skill_report = reports
+        .iter()
+        .find(|r| {
+            r["file"]
+                .as_str()
+                .map(|f| f.ends_with("skill.md"))
+                .unwrap_or(false)
+        })
+        .expect("skill.md report present");
+    assert!(
+        !skill_report["baselined"]
+            .as_array()
+            .expect("array")
+            .is_empty(),
+        "the ./-prefixed path that `check .` reports must match the entry a baseline written \
+         the same way recorded: {skill_report}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn baselined_findings_carry_full_evidence_and_the_top_level_stays_an_array() {
+    let fixture = fixture_path();
+    let fixture = fixture.to_str().expect("utf-8 path");
+    let baseline = baseline_path("evidence");
+
+    run(&[
+        "check",
+        fixture,
+        "--write-baseline",
+        baseline.to_str().expect("utf-8 path"),
+        "--quiet",
+    ]);
+
+    let (code, stdout, _) = run(&[
+        "check",
+        fixture,
+        "--baseline",
+        baseline.to_str().expect("utf-8 path"),
+        "--format",
+        "json",
+    ]);
+    assert_eq!(code, 0);
+
+    let parsed: Vec<injection_scanner::pattern::ScanReport> = serde_json::from_str(&stdout)
+        .expect("the top level must parse as Vec<ScanReport>, not a bare Value");
+    let report = parsed
+        .iter()
+        .find(|r| r.file == fixture)
+        .expect("report present");
+    assert!(report.matches.is_empty());
+    assert!(!report.baselined.is_empty());
+    let evidence = &report.baselined[0];
+    assert!(
+        !evidence.matched_text.is_empty(),
+        "a baselined record must keep the evidence, not just an id"
+    );
+    assert!(!evidence.message.is_empty());
+    assert!(!evidence.pattern_name.is_empty());
+    assert!(!evidence.remediation.is_empty());
+    assert_eq!(report.critical_count, 0);
+
+    let _ = std::fs::remove_file(&baseline);
+}

--- a/tests/baseline_test.rs
+++ b/tests/baseline_test.rs
@@ -738,3 +738,55 @@ fn duplicate_entries_for_one_fingerprint_sum_their_counts() {
          count 2 does. stdout:\n{stdout}\nstderr:\n{stderr}"
     );
 }
+
+#[test]
+fn an_entry_whose_file_was_not_scanned_is_not_called_stale() {
+    // Stale means "this file was scanned and the finding is gone", so it can
+    // only be judged about files the run actually looked at. The pre-commit
+    // hook scans ONLY staged files, so on a commit touching one unrelated file
+    // every other entry consumes zero occurrences — and reporting all of them
+    // as prunable, on every commit, is how a warning becomes wallpaper.
+    let scanned = Doc::new("scanned-file.md", "clean prose, nothing here\n");
+    let absent = Doc::new("absent-file.md", "clean prose, nothing here\n");
+    let baseline = Doc::new("partial-scan-baseline.json", "{}");
+
+    // An entry naming a file this run will never open.
+    baseline.write(&format!(
+        r#"{{"version":1,"generated_by":"test","entries":[
+            {{"file":{},"pattern_id":"PI001",
+              "digest":"sha256:{}","count":1,"first_seen_line":1}}]}}"#,
+        serde_json::to_string(absent.path()).expect("encode path"),
+        "0".repeat(64)
+    ));
+
+    let (code, _, stderr) = run(&["check", scanned.path(), "--baseline", baseline.path()]);
+
+    assert_eq!(code, 0, "the scanned file is clean: {stderr}");
+    assert!(
+        !stderr.contains("can be pruned"),
+        "an entry for a file outside this run's scope says nothing about whether \
+         the finding is gone — calling it prunable on every partial scan buries \
+         the genuinely stale entries the note exists to surface. stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn an_entry_whose_file_was_scanned_and_is_clean_is_still_called_stale() {
+    // The negative case for the test above: narrowing "stale" to scanned files
+    // must not narrow it to nothing.
+    let doc = Doc::new("went-clean.md", include_str!("fixtures/injected-skill.md"));
+    let baseline = Doc::new("went-clean-baseline.json", "{}");
+
+    let (code, _, stderr) = run(&["check", doc.path(), "--write-baseline", baseline.path()]);
+    assert_eq!(code, 0, "--write-baseline must exit 0: {stderr}");
+
+    doc.write("the payload has been removed\n");
+    let (code, _, stderr) = run(&["check", doc.path(), "--baseline", baseline.path()]);
+
+    assert_eq!(code, 0, "the file is clean now: {stderr}");
+    assert!(
+        stderr.contains("can be pruned"),
+        "this file WAS scanned and its findings are gone — that entry is a live \
+         licence to re-introduce them and must still be reported. stderr:\n{stderr}"
+    );
+}

--- a/tests/install_hook_test.rs
+++ b/tests/install_hook_test.rs
@@ -243,3 +243,137 @@ fn the_pre_commit_framework_manifest_is_valid() {
         );
     }
 }
+
+// ---- the hook composed with a baseline (CLI-08 x HOOK-01) ----
+//
+// These guard the seam the two features meet at. `--baseline` is worth nothing
+// to an adopting team if the hook — the thing that actually blocks their
+// commits — cannot honour it. Found in review: the adoption flow read clean
+// when driven by hand and still blocked every commit once the hook was
+// installed.
+
+/// Writes a baseline for the repo's current content and returns its path.
+fn write_baseline(repo: &Repo, rel: &str) -> PathBuf {
+    let path = repo.0.join(rel);
+    let out = Command::new(binary())
+        .args(["check", "."])
+        .arg("--write-baseline")
+        .arg(&path)
+        .current_dir(&repo.0)
+        .output()
+        .expect("run scanner");
+    assert!(
+        out.status.success(),
+        "--write-baseline must exit 0: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(path.exists(), "no baseline written to {}", path.display());
+    path
+}
+
+#[test]
+fn a_hook_installed_with_a_baseline_lets_the_accepted_state_commit() {
+    let repo = Repo::new("baseline-accepts");
+    repo.write("legacy.md", include_str!("fixtures/injected-skill.md"));
+    repo.git(&["add", "-A"]);
+    let baseline = write_baseline(&repo, ".injection-scanner-baseline.json");
+
+    let (ok, output) = repo.scanner(&[
+        "install-hook",
+        "--baseline",
+        baseline.to_str().expect("utf-8 path"),
+    ]);
+    assert!(ok, "install-hook --baseline failed: {output}");
+
+    let (committed, output) = commit(&repo, "adopt the existing state");
+    assert!(
+        committed,
+        "a repository that accepted its findings into a baseline must be able to \
+         commit — this is the entire point of CLI-08, and it is worthless if the \
+         hook that gates the commit ignores the baseline. Output:\n{output}"
+    );
+}
+
+#[test]
+fn a_hook_installed_with_a_baseline_still_blocks_a_new_finding() {
+    let repo = Repo::new("baseline-still-blocks");
+    repo.write("legacy.md", include_str!("fixtures/injected-skill.md"));
+    repo.git(&["add", "-A"]);
+    let baseline = write_baseline(&repo, ".injection-scanner-baseline.json");
+    let (ok, output) = repo.scanner(&[
+        "install-hook",
+        "--baseline",
+        baseline.to_str().expect("utf-8 path"),
+    ]);
+    assert!(ok, "install-hook --baseline failed: {output}");
+
+    // A brand-new file carrying the same payload is NOT in the baseline: the
+    // path is part of an entry's identity. Accepting yesterday's debt must
+    // never become a licence to add more of it.
+    repo.write("fresh.md", include_str!("fixtures/injected-skill.md"));
+    repo.git(&["add", "-A"]);
+
+    let (committed, output) = commit(&repo, "sneak in a new payload");
+    assert!(
+        !committed,
+        "a baseline accepts the findings it recorded and nothing else — a NEW \
+         file with the same payload must still block the commit, or the baseline \
+         is a blanket amnesty. Output:\n{output}"
+    );
+}
+
+#[test]
+fn the_baseline_path_is_absolute_in_the_generated_hook() {
+    let repo = Repo::new("baseline-abs");
+    repo.write("legacy.md", include_str!("fixtures/injected-skill.md"));
+    repo.git(&["add", "-A"]);
+    write_baseline(&repo, ".injection-scanner-baseline.json");
+
+    // Invoked the way a user does it: from inside the repository, with a
+    // relative path. Resolving that against the caller's cwd is what makes the
+    // absolutisation below load-bearing.
+    let out = Command::new(binary())
+        .args([
+            "install-hook",
+            "--baseline",
+            ".injection-scanner-baseline.json",
+        ])
+        .current_dir(&repo.0)
+        .output()
+        .expect("run scanner");
+    assert!(
+        out.status.success(),
+        "install-hook --baseline failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let script = fs::read_to_string(repo.hook()).expect("read hook");
+    let line = script
+        .lines()
+        .find(|l| l.contains("--baseline"))
+        .expect("the generated hook must pass --baseline");
+    assert!(
+        line.contains(&format!(
+            "{}",
+            repo.0.join(".injection-scanner-baseline.json").display()
+        )),
+        "the hook runs from inside a temp staging copy, so a RELATIVE baseline \
+         path resolves against that copy and does not exist — it must be \
+         absolutised at install time. Got: {line}"
+    );
+}
+
+#[test]
+fn install_hook_rejects_a_baseline_that_does_not_exist() {
+    let repo = Repo::new("baseline-missing");
+    let (ok, output) = repo.scanner(&["install-hook", "--baseline", "nope.json"]);
+    assert!(
+        !ok,
+        "installing a hook against a nonexistent baseline would produce a hook \
+         that fails on every commit, long after the typo was made. Output:\n{output}"
+    );
+    assert!(
+        !repo.hook().exists(),
+        "a rejected install must not leave a hook behind: {output}"
+    );
+}

--- a/tests/report_roundtrip_test.rs
+++ b/tests/report_roundtrip_test.rs
@@ -150,3 +150,63 @@ fn a_withheld_finding_survives_the_round_trip_with_its_evidence() {
         "and the score that explains why it was withheld"
     );
 }
+
+/// `baselined` is additive in exactly the same way (CLI-08), and gets the
+/// same guarantee: a report written before it existed must still load.
+#[test]
+fn a_report_written_before_baselined_existed_still_loads() {
+    // A v0.0.3-shaped report: `suppressed` and `low_confidence` present,
+    // `baselined` absent.
+    let legacy = r#"{
+        "file": "doc.md",
+        "matches": [],
+        "suppressed": [],
+        "low_confidence": [],
+        "critical_count": 0,
+        "high_count": 0,
+        "medium_count": 0,
+        "low_count": 0
+    }"#;
+
+    let restored: ScanReport =
+        serde_json::from_str(legacy).expect("a pre-baselined report must still deserialize");
+    assert!(
+        restored.baselined.is_empty(),
+        "a missing `baselined` key must default to empty, not fail the parse"
+    );
+    assert_eq!(restored.file, "doc.md");
+}
+
+/// The `suppression_symmetry_test.rs` property, applied to the new array: a
+/// finding filed under "baselined" and the same finding filed under
+/// "matches" must be indistinguishable records.
+#[test]
+fn a_baselined_finding_and_the_same_finding_reported_are_the_identical_record() {
+    let finding = sample_match("PI001");
+
+    let reported = ScanReport::with_baselined(
+        "skill.md".to_string(),
+        vec![finding.clone()],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let baselined = ScanReport::with_baselined(
+        "skill.md".to_string(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        vec![finding],
+    );
+
+    assert_eq!(
+        serde_json::to_value(&reported.matches[0]).expect("serialisable"),
+        serde_json::to_value(&baselined.baselined[0]).expect("serialisable"),
+        "a baselined finding and the same finding reported must be identical records — a \
+         consumer cannot describe what was accepted if the record differs in shape"
+    );
+    assert_eq!(
+        baselined.critical_count, 0,
+        "a baselined finding must not be counted in the severity tallies"
+    );
+}


### PR DESCRIPTION
Closes the last open item on #25 — `--baseline`, the requirement `.planning/REQUIREMENTS.md`
tracks as **CLI-08**. An existing repository cannot adopt this scanner if day one is a wall of
findings; a baseline accepts the current state once, so only *new* findings fail the build.

```bash
injection-scanner check . --write-baseline .injection-scanner-baseline.json
injection-scanner install-hook --baseline .injection-scanner-baseline.json
```

## What an entry records

Identity is `(file, pattern_id, sha256(matched_text))` plus an occurrence `count`.

**The payload is hashed, not stored.** `json` is in `DEFAULT_EXTENSIONS`, so a committed
baseline holding verbatim payloads would be flagged by the very next scan — the adoption
artifact would become a finding source. Confirmed live, not just in a test: `check . --baseline
b.json` scans `./b.json` as its own report and finds nothing. Hashing also closes a real attack,
since the adversary authors the scanned text and a weak digest would let a *new* payload be
tuned onto an already-accepted fingerprint.

**Line number is deliberately excluded from identity**, so editing above a finding does not force
regeneration — the file stays a record of a decision rather than churn on every commit. **`count`
bounds acceptance**: baselining two occurrences accepts two, and a third is still reported.

Full rationale and the rejected alternatives: `docs/adr/ADR-002-baseline-fingerprints.md`.

## Nothing is dropped

`--baseline` moves findings into a fourth array, `ScanReport.baselined`, alongside `matches`,
`suppressed` and `low_confidence` — same type, same full evidence, filed under a third distinct
reason a finding can be withheld. Severity tallies never count a baselined finding. The top-level
JSON stays an array of report objects, so `spec-ci-plugin`'s `JSON.parse(output) as Array<...>`
is unaffected, and a v0.0.3-era report still deserializes.

## The seam that review caught

`--baseline` and `install-hook` were each well tested and **did not compose**. The generated hook
hardcoded `check . --fail-on <bar> --no-ignore`, so a repo that adopted a baseline still could not
commit — the exact wall CLI-08 exists to remove, rebuilt one layer down. `install-hook --baseline`
now exists; the path is canonicalised at install time, because the hook scans from inside a temp
staging copy where a relative path would not exist, and an unresolvable path is refused at install
rather than on someone's next commit.

Pinned in both directions: the accepted state commits, and the **same payload in a new file still
blocks** — the path is part of an entry's identity, so this is not a blanket amnesty.

## Verified

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, **203 tests** green.

Beyond the suite, checked by hand against the real binary: a homoglyph variant of an accepted
payload does **not** inherit its fingerprint (the digest is over `original_slice`, not the
normalized text); a duplicate past `count` still exits 1; stale entries are named on stderr;
malformed, unknown-version and missing baselines are hard errors; both flags together and
`--write-baseline` with `check -` are rejected, the latter before stdin is read and without
creating the file.

Also from review: `--write-baseline` no longer jumps over the "N file(s) skipped and NOT scanned"
summary, `Baseline` gained the `deny_unknown_fields` that `BaselineEntry` already carried, and
duplicate identities sum their counts instead of the last one winning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)