### PR TITLE
test: coverage gate, benchmark run, and the per-pattern test policy as a ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@ jobs:
   test:
     name: fmt · clippy · test · build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Raised from 15 when the coverage gate landed: llvm-cov rebuilds the whole
+    # tree with instrumentation, which roughly doubles the compile leg.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -62,7 +64,8 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: stable
-          components: clippy, rustfmt
+          # llvm-tools-preview is what cargo-llvm-cov needs for the coverage gate below.
+          components: clippy, rustfmt, llvm-tools-preview
 
       - name: Cache cargo registry and target
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -84,6 +87,42 @@ jobs:
 
       - name: cargo test
         run: cargo test --locked
+
+      # TEST-02 (issue #29). The criterion benches in `benches/scan.rs` cover the
+      # four shapes that matter — pattern-set compile, one large file, 500 small
+      # files, and a pathological line — but nothing ran them, so they could rot
+      # unnoticed until someone needed a measurement and found a broken harness.
+      #
+      # `--test` is criterion's own mode: it executes each benchmark exactly once
+      # and asserts it completes, in seconds rather than minutes. Timing on a
+      # shared hosted runner is too noisy to gate on, so the numeric regression
+      # guards live where they can be trusted: the machine-independent ratio in
+      # `tests/perf_regression_test.rs`, and the end-to-end budget below.
+      - name: Benchmarks run
+        run: cargo bench --locked -- --test
+
+      # TEST-01 (issue #29). Both CLAUDE.md files require ">80% coverage on core
+      # logic before any release", and until now nothing measured it.
+      #
+      # The threshold is 85%, not 80. Coverage measured 93.65% of lines when this
+      # gate landed, so a bar at the documented 80% would permit a silent 13-point
+      # slide before anyone noticed — a gate that only fires after the damage is
+      # not a gate. 85% keeps ~8 points of headroom for ordinary churn while still
+      # catching a real erosion. Raise it as coverage rises; never lower it to make
+      # a red build green.
+      #
+      # Worth knowing: llvm-cov builds into `target/llvm-cov-target/`, which is
+      # exactly how the stale-binary bug in #61 was found — 14 CLI tests passing
+      # against a binary they never built. `tests/test_harness_contract_test.rs`
+      # guards that now, and running coverage in CI re-exercises the guard under
+      # the alternate target directory that exposed it.
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Coverage gate — 85% of lines
+        run: cargo llvm-cov --locked --summary-only --fail-under-lines 85
 
       - name: cargo build --release
         run: cargo build --release --locked

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -125,5 +125,16 @@ if your pattern fires there, the grade is not the problem.
 3. Include in your PR:
    - At least 3 true positive test cases
    - At least 2 non-match cases (false positive prevention)
-4. Run `cargo test`
-5. Submit PR with title: `feat: add PI0XX pattern-name`
+
+   Both are enforced in CI by `tests/pattern_policy_test.rs` — add them with the
+   `assert_positives` / `assert_negatives` helpers in `tests/pattern_test.rs`.
+
+   **Make the non-match cases near-misses.** A negative that fails for a trivial
+   reason proves nothing. The cautionary example is PI048, which shipped with
+   negatives `shortToken123`, `not-base64-at-all!!!` and `abcd` — every one of
+   them failing on *length* — and still matched any file path over 48
+   characters, for 3,494 false positives on our own documentation. Write the
+   legitimate text you would most fear the pattern firing on.
+4. Regenerate the catalogue: `cargo run --release -- rules --format markdown > docs/PATTERN-CATALOGUE.md`
+5. Run `cargo test`
+6. Submit PR with title: `feat: add PI0XX pattern-name`

--- a/tests/pattern_policy_test.rs
+++ b/tests/pattern_policy_test.rs
@@ -1,0 +1,212 @@
+//! Enforces the `PATTERNS.md` per-pattern test policy in CI instead of by hand
+//! (#70, split out of #27).
+//!
+//! The policy — at least 3 match cases and 2 non-match cases per pattern — was
+//! a convention a reviewer had to remember. PR #66 is the evidence for why
+//! that is not enough: its patterns each shipped with positives and negatives,
+//! and the negatives still did not catch that PI048's `[A-Za-z0-9+/]{48,}`
+//! matched any file path over 48 characters, for 3,494 false positives on our
+//! own documentation.
+//!
+//! So this counts cases; it cannot judge whether they are *good* cases. A
+//! negative that fails on length rather than on shape proves nothing. The
+//! false-positive corpus in `tests/corpus/clean/` is the gate that catches
+//! that, and `PATTERNS.md` asks for near-misses rather than obvious non-matches.
+//!
+//! ## The ratchet
+//!
+//! 30 of the original patterns predate the helpers and have no cases at all.
+//! Rather than block on backfilling them (#89) or leave the policy unenforced,
+//! they are listed in [`LEGACY_UNTESTED`]. That list is a debt register with
+//! three properties, each pinned by a test below: a pattern not on it must
+//! comply, the list may not grow, and an entry that *starts* complying must be
+//! removed from it. The last one is what makes this tighten on its own rather
+//! than becoming a permanent excuse.
+
+use injection_scanner::patterns::load_embedded_patterns;
+use std::collections::BTreeMap;
+
+/// Minimums from `PATTERNS.md`.
+const MIN_POSITIVES: usize = 3;
+const MIN_NEGATIVES: usize = 2;
+
+/// Patterns that shipped before `assert_positives`/`assert_negatives` existed.
+///
+/// **Do not add to this list.** A new pattern without cases must gain cases,
+/// not an exemption. Backfilling is tracked in #89; remove ids from here as
+/// they are covered — a test below fails if you leave a compliant id behind.
+const LEGACY_UNTESTED: &[&str] = &[
+    "PI001", "PI002", "PI003", "PI004", "PI005", "PI006", "PI007", "PI010", "PI011", "PI012",
+    "PI013", "PI014", "PI020", "PI021", "PI022", "PI023", "PI024", "PI025", "PI030", "PI031",
+    "PI032", "PI033", "PI034", "PI035", "PI036", "PI037", "PI038", "PI040", "PI041", "PI042",
+];
+
+/// Counts of `(positive, negative)` cases per pattern id across `tests/`.
+///
+/// Counts *cases*, not call sites: three ids each with one case is not the
+/// same as one id with three, and the policy is about the latter.
+fn case_counts() -> BTreeMap<String, (usize, usize)> {
+    let mut counts: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+
+    for entry in std::fs::read_dir(&dir).expect("tests/ must be readable") {
+        let path = entry.expect("readable dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let source = std::fs::read_to_string(&path).expect("test source must be readable");
+        for (helper, slot) in [("assert_positives", 0usize), ("assert_negatives", 1usize)] {
+            for (id, cases) in calls(&source, helper) {
+                let entry = counts.entry(id).or_insert((0, 0));
+                if slot == 0 {
+                    entry.0 += cases;
+                } else {
+                    entry.1 += cases;
+                }
+            }
+        }
+    }
+    counts
+}
+
+/// Finds `helper("PI0XX", &[ ... ])` calls and counts the string literals in
+/// each. Deliberately simple: a hand-rolled scan beats a regex dependency for
+/// a shape this fixed, and anything it cannot parse counts as zero, which
+/// fails safe — the policy test complains rather than passing silently.
+fn calls(source: &str, helper: &str) -> Vec<(String, usize)> {
+    let needle = format!("{helper}(");
+    let mut out = Vec::new();
+    let bytes = source.as_bytes();
+    let mut from = 0;
+
+    while let Some(rel) = source[from..].find(&needle) {
+        let start = from + rel + needle.len();
+        from = start;
+
+        let Some(open) = source[start..].find('"') else {
+            continue;
+        };
+        let id_start = start + open + 1;
+        let Some(close) = source[id_start..].find('"') else {
+            continue;
+        };
+        let id = &source[id_start..id_start + close];
+        if !(id.len() == 5 && id.starts_with("PI") && id[2..].bytes().all(|b| b.is_ascii_digit())) {
+            continue;
+        }
+
+        // Count literals between the `&[` and its matching `]`.
+        let Some(bracket) = source[id_start + close..].find('[') else {
+            continue;
+        };
+        let body_start = id_start + close + bracket + 1;
+        let mut depth = 1usize;
+        let mut i = body_start;
+        let mut cases = 0usize;
+        let mut in_string = false;
+        let mut escaped = false;
+
+        while i < bytes.len() && depth > 0 {
+            let c = bytes[i] as char;
+            if in_string {
+                if escaped {
+                    escaped = false;
+                } else if c == '\\' {
+                    escaped = true;
+                } else if c == '"' {
+                    in_string = false;
+                }
+            } else {
+                match c {
+                    '"' => {
+                        in_string = true;
+                        cases += 1;
+                    }
+                    '[' => depth += 1,
+                    ']' => depth -= 1,
+                    _ => {}
+                }
+            }
+            i += 1;
+        }
+        out.push((id.to_string(), cases));
+    }
+    out
+}
+
+fn all_ids() -> Vec<String> {
+    load_embedded_patterns()
+        .expect("patterns must load")
+        .iter()
+        .flat_map(|c| c.patterns.iter())
+        .map(|p| p.id.clone())
+        .collect()
+}
+
+#[test]
+fn every_pattern_meets_the_test_case_policy() {
+    let counts = case_counts();
+    let mut failures = Vec::new();
+
+    for id in all_ids() {
+        if LEGACY_UNTESTED.contains(&id.as_str()) {
+            continue;
+        }
+        let (pos, neg) = counts.get(&id).copied().unwrap_or((0, 0));
+        if pos < MIN_POSITIVES || neg < MIN_NEGATIVES {
+            failures.push(format!("{id}: {pos} positive(s), {neg} negative(s)"));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "PATTERNS.md requires at least {MIN_POSITIVES} match cases and {MIN_NEGATIVES} \
+         non-match cases per pattern, added with assert_positives / assert_negatives in \
+         tests/pattern_test.rs.\n\nBelow the bar:\n  {}\n\nMake the negatives near-misses \
+         — legitimate text the pattern could plausibly fire on. A negative that fails for \
+         a trivial reason proves nothing.",
+        failures.join("\n  ")
+    );
+}
+
+#[test]
+fn the_legacy_exemption_list_does_not_grow() {
+    assert!(
+        LEGACY_UNTESTED.len() <= 30,
+        "LEGACY_UNTESTED is a debt register, not an escape hatch — it had 30 entries when \
+         #70 landed and must only ever shrink. A new pattern needs test cases, not an \
+         exemption."
+    );
+    let ids = all_ids();
+    let stale: Vec<&str> = LEGACY_UNTESTED
+        .iter()
+        .copied()
+        .filter(|id| !ids.contains(&id.to_string()))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "LEGACY_UNTESTED names patterns that no longer exist: {stale:?}. Remove them."
+    );
+}
+
+#[test]
+fn a_legacy_pattern_that_now_complies_must_leave_the_list() {
+    // Without this the list would be a ratchet that never tightens: someone
+    // backfills the cases, the exemption stays, and the next change to that
+    // pattern is unguarded again.
+    let counts = case_counts();
+    let graduated: Vec<String> = LEGACY_UNTESTED
+        .iter()
+        .filter(|id| {
+            let (pos, neg) = counts.get(**id).copied().unwrap_or((0, 0));
+            pos >= MIN_POSITIVES && neg >= MIN_NEGATIVES
+        })
+        .map(|id| (*id).to_string())
+        .collect();
+
+    assert!(
+        graduated.is_empty(),
+        "these patterns now meet the policy and must be removed from LEGACY_UNTESTED \
+         so they stay enforced: {graduated:?}"
+    );
+}


### PR DESCRIPTION
Closes the three measurement gaps left in Phase 4: TEST-01, TEST-02 and DOCS-02.

## Coverage (TEST-01, #29)

Both CLAUDE.md files require *">80% coverage on core logic before any release"*. Nothing measured it. Now: `cargo llvm-cov --fail-under-lines 85`.

**The threshold is 85, not the documented 80, on purpose.** Coverage measures **93.65% of lines** today, so a bar at 80 would permit a silent 13-point slide before it ever fired. A gate that only trips after the damage isn't a gate. 85 leaves ~8 points of headroom for ordinary churn.

| | Regions | Lines |
|---|---|---|
| Total | 93.49% | 93.65% |
| `main.rs` (CLI wiring) | 82.15% | 85.96% |
| `patterns/mod.rs` | 82.03% | 77.00% |
| Everything else | 91–100% | 91–100% |

Mutation-tested: `--fail-under-lines 99` exits 1, `85` exits 0.

There's a side benefit worth knowing. `llvm-cov` builds into `target/llvm-cov-target/`, which is exactly how #61's stale-binary bug surfaced — 14 CLI tests reporting green against a binary they never built. Running coverage in CI re-exercises `test_harness_contract_test.rs` under the alternate target directory that exposed it.

## Benchmarks (TEST-02, #29)

`benches/scan.rs` already covers the four shapes #29 asks for — pattern-set compile, one large file, 500 small files, a pathological line — and **nothing ran them**, so the harness could rot unnoticed until someone needed a measurement.

`cargo bench -- --test` is criterion's own mode: each benchmark executes once and must complete, in seconds rather than minutes.

Deliberately **not** a timing gate. A shared hosted runner is too noisy to gate on, so the numeric guards stay where they can be trusted: the machine-independent ratio in `perf_regression_test.rs`, and the end-to-end 200ms budget already in this workflow.

## Per-pattern test policy (DOCS-02, #70)

`PATTERNS.md` has always asked for ≥3 match and ≥2 non-match cases. It was a convention a reviewer had to remember.

The complication: **only 18 of 48 patterns comply.** The other 30 predate the `assert_positives`/`assert_negatives` helpers and have no cases at all — so a hard gate couldn't be switched on today, and a soft one would never be. Hence a ratchet, with three rules each pinned by a test:

- a pattern **not** on `LEGACY_UNTESTED` must comply
- the list **may not grow** — a new pattern needs cases, not an exemption
- an id on the list that **starts** complying must be **removed** from it

That third rule is what makes it tighten on its own. Without it, someone backfills the cases, the exemption stays, and that pattern is unguarded again on its next change. Backfilling the 30 is #89.

Both failure directions mutation-tested:

```
dropping PI001 from the list → PI001: 0 positive(s), 0 negative(s)
adding compliant PI008       → must be removed from LEGACY_UNTESTED: ["PI008"]
```

**What this cannot do is judge whether the cases are good**, and #70 is explicit about why that matters: PI048 shipped with negatives (`shortToken123`, `abcd`) that all failed on *length* rather than shape, and still matched every file path over 48 characters — 3,494 false positives on our own docs. `PATTERNS.md` now asks for near-misses and uses PI048 as the cautionary example.

## Verification

```
cargo fmt --all -- --check                          PASS
cargo clippy --all-targets --locked -- -D warnings  PASS
cargo test --locked                                 PASS — 259 passed, 0 failed
cargo bench --locked -- --test                      PASS — 4 benchmarks
cargo llvm-cov --fail-under-lines 85                PASS — 93.65%
```

`timeout-minutes` 15 → 30, since the instrumented rebuild roughly doubles the compile leg. `cargo-llvm-cov` installs via `taiki-e/install-action`, SHA-pinned like every other action here.

**The runner, triggers and `contents: read` are untouched** — the GitHub-hosted runner is the sanctioned D-02 exception, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
